### PR TITLE
Display attrs on group#show

### DIFF
--- a/app/models/sac_cas/group.rb
+++ b/app/models/sac_cas/group.rb
@@ -15,6 +15,12 @@ module SacCas::Group
     # self.superior_attributes = [:bank_account]
 
     root_types Group::SacCas
+
+    alias_method :group_id, :id
+  end
+
+  def sektion_or_ortsgruppe?
+    [Group::Sektion, Group::Ortsgruppe].any? { |c| is_a?(c) }
   end
 
   def preferred_primary?

--- a/app/views/groups/_attrs_sac_cas.html.haml
+++ b/app/views/groups/_attrs_sac_cas.html.haml
@@ -1,0 +1,7 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+- if entry.sektion_or_ortsgruppe?
+  = render_present_attrs entry, :group_id, :navision_id

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -43,6 +43,9 @@ de:
           m: Mann
           w: Frau
           _nil: Andere
+      group:
+        group_id: Gruppen-ID
+        navision_id: NAV Sektions-ID
       group/sektion:
         foundation_year: Gründungsjahr
         section_canton: Kanton

--- a/spec/views/groups/_attrs_sac_cas.html.haml_spec.rb
+++ b/spec/views/groups/_attrs_sac_cas.html.haml_spec.rb
@@ -1,0 +1,59 @@
+# encoding: utf-8
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require 'spec_helper'
+describe 'groups/_attrs_sac_cas.html.haml' do
+  include FormatHelper
+
+  let(:dom) { render; Capybara::Node::Simple.new(@rendered)  }
+
+  before do
+    allow(view).to receive_messages(current_user: Person.new)
+    allow(view).to receive_messages(entry: GroupDecorator.decorate(group))
+    allow(controller).to receive_messages(current_user: Person.new)
+    assign(:sub_groups, 'Gruppen' => [], 'Untergruppen' => [])
+    assign(:group, group)
+  end
+
+  context 'sektion' do
+    let(:group) { groups(:bluemlisalp) }
+
+    it 'renders sektions and nav sektions id fields' do
+      expect(dom).to have_css 'dl dt', text: 'Gruppen-ID'
+      expect(dom).to have_css 'dl dd', text: group.id
+
+      expect(dom).to have_css 'dl dt', text: 'NAV Sektions-ID'
+      expect(dom).to have_css 'dl dd', text: group.navision_id
+    end
+
+    it 'does not render and nav sektions id if blank' do
+      group.update_columns(navision_id: nil)
+      expect(dom).not_to have_css 'dl dt', text: 'NAV Sektions-ID'
+    end
+  end
+
+  context 'ortsgruppe' do
+    let(:group) { Fabricate(Group::Ortsgruppe.sti_name, parent: groups(:bluemlisalp), navision_id: 123, foundation_year: 2000) }
+
+    it 'renders sektions and nav sektions id fields' do
+      expect(dom).to have_css 'dl dt', text: 'Gruppen-ID'
+      expect(dom).to have_css 'dl dd', text: group.id
+
+      expect(dom).to have_css 'dl dt', text: 'NAV Sektions-ID'
+      expect(dom).to have_css 'dl dd', text: group.navision_id
+    end
+  end
+
+  context 'mitglieder' do
+    let(:group) { groups(:bluemlisalp_mitglieder) }
+
+    it 'does not render sektions and nav sektions id fields' do
+      expect(dom).not_to have_css 'dl dt', text: 'Gruppen-ID'
+      expect(dom).not_to have_css 'dl dt', text: 'NAV Sektions-ID'
+    end
+  end
+end


### PR DESCRIPTION
Anpassungen an der view sind gemacht. Das Naming `Sektion-ID` für `group#id` bei den Ortsgruppen finde ich aber problematisch. 

Auch ob es tatsächlich noch API anpassungen braucht ist mir nicht klar, beide Attribute sind ja schon im API drinnen als (`id` bzw `navision_id`)