### PR TITLE
Add button to push cost models from kind_category to kind, (#359)

### DIFF
--- a/app/controllers/sac_cas/event/kind_categories_controller.rb
+++ b/app/controllers/sac_cas/event/kind_categories_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module SacCas::Event::KindCategoriesController
+  extend ActiveSupport::Concern
+
+  prepended  do
+    self.permitted_attrs += [:cost_center_id, :cost_unit_id]
+  end
+
+  def push_down
+    authorize!(:update, entry)
+    entry.push_down_inherited_attributes!
+    message = t('.success', cost_center: entry.cost_center, cost_unit: entry.cost_unit)
+    redirect_to edit_event_kind_category_path(entry), flash: { notice: message }
+  end
+
+  private
+
+  def load_assocations
+    super
+    @cost_centers = CostCenter.includes(:translations).list
+    @cost_units = CostUnit.includes(:translations).list
+  end
+
+  def list_entries
+    super.includes(:translations,
+                   cost_center: :translations,
+                   cost_unit: :translations,
+                   kinds: :translations)
+  end
+end

--- a/app/models/sac_cas/event/kind_category.rb
+++ b/app/models/sac_cas/event/kind_category.rb
@@ -30,4 +30,8 @@ module SacCas::Event::KindCategory
     belongs_to :cost_center
     belongs_to :cost_unit
   end
+
+  def push_down_inherited_attributes!
+    kinds.update_all(cost_unit_id: cost_unit.id, cost_center_id: cost_center.id)
+  end
 end

--- a/app/views/event/kind_categories/_actions_edit.html.haml
+++ b/app/views/event/kind_categories/_actions_edit.html.haml
@@ -1,0 +1,6 @@
+- #  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+- #  hitobito_sac_cas and licensed under the Affero General Public License version 3
+- #  or later. See the COPYING file at the top-level directory or at
+- #  https://github.com/hitobito/hitobito.
+
+= action_button(t('.push_down_button'), push_down_event_kind_category_path(entry), :'level-down-alt', data: { method: :put, confirm: t('.push_down_button_confirm') })

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -413,6 +413,17 @@ de:
     sessions:
       form:
         login_identity: Haupt‑E‑Mail / Mitglied‑Nr
+  event:
+    kind_categories:
+      push_down:
+        success: Kostenstelle (%{cost_center}) und Kostenträger (%{cost_unit}) wurden auf alle
+          zugeordneten Kursarten übertragen.
+
+      actions_edit:
+        push_down_button: Daten auf Kursarten übertragen
+        push_down_button_confirm: Wollen Sie wirklich die gespeicherten Daten (Kostenstelle und
+          Kostenträger) auf alle Kursarten übertragen? Dabei werden die aktuellen Werte
+          überschrieben.
 
   person:
     history:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,5 +35,9 @@ Rails.application.routes.draw do
 
     resources :cost_centers, except: [:show]
     resources :cost_units, except: [:show]
+
+    resources :event_kind_categories, module: 'event', controller: 'kind_categories', only: [] do
+      put :push_down, on: :member
+    end
   end
 end

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -76,7 +76,7 @@ module HitobitoSacCas
       ## Controllers
       EventsController.prepend SacCas::EventsController
       Event::KindsController.prepend SacCas::Event::KindsController
-      Event::KindCategoriesController.permitted_attrs += [:cost_center_id, :cost_unit_id]
+      Event::KindCategoriesController.prepend SacCas::Event::KindCategoriesController
       GroupsController.permitted_attrs << :mitglied_termination_by_section_only
       Groups::SelfInscriptionController.prepend SacCas::Groups::SelfInscriptionController
       Groups::SelfRegistrationController.prepend SacCas::Groups::SelfRegistrationController

--- a/spec/fixtures/event/kinds.yml
+++ b/spec/fixtures/event/kinds.yml
@@ -39,3 +39,4 @@ ski_course:
   cost_center: course
   cost_unit: ski
   level: ek
+  kind_category: ski_course

--- a/spec/models/event/kind_category_spec.rb
+++ b/spec/models/event/kind_category_spec.rb
@@ -27,4 +27,16 @@ describe Event::KindCategory do
       expect(category.errors[:cost_unit_id]).to eq ['muss ausgefüllt werden']
     end
   end
+
+  describe '#push_down_inherited_attributes' do
+    subject(:category) { event_kind_categories(:ski_course) }
+    let(:event_kind) { event_kinds(:ski_course) }
+
+    it 'overrides cost model on each associated event_kind' do
+      event_kind.update!(cost_center: Fabricate(:cost_center), cost_unit: Fabricate(:cost_unit))
+      category.push_down_inherited_attributes!
+      expect(event_kind.reload.cost_center).to eq category.cost_center
+      expect(event_kind.cost_unit).to eq category.cost_unit
+    end
+  end
 end


### PR DESCRIPTION
Das im ticket beschriebene icon existiert in Fontawesome 5 nicht, ich hab jetzt was analoges genommen.  