### PR TITLE
Add additional mailing_lists as mounted attrs to root, (#504)

### DIFF
--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -188,6 +188,12 @@ de:
         sac_cas_self_registration_url: SAC Selbstregistrierung
       group/sac_cas:
         sac_newsletter_mailing_list_id: SAC Newsletter Abo ID
+        sac_magazine_mailing_list_id: Die Alpen Abo ID
+        sac_inside_mailing_list_id: SAC Inside Abo ID
+        sac_tourenportal_mailing_list_id: SAC Tourenportal Abo ID
+        sac_magazin_mailing_list_id: SAC Magazin Abo ID
+        sac_huettenportal_mailing_list_id: SAC Hüttenportal Abo ID
+
         course_admin_email: E-Mail Kursadministration
       group/sektion:
         foundation_year: Gründungsjahr

--- a/spec/models/group/sac_cas_spec.rb
+++ b/spec/models/group/sac_cas_spec.rb
@@ -11,22 +11,26 @@ describe Group::SacCas do
   let(:group) { groups(:root) }
 
   context 'validations' do
-    context 'sac_newsletter_mailing_list_id' do
-      it 'allows empty value' do
-        expect(group).to be_valid
-      end
+    [:newsletter, :inside, :tourenportal, :magazin, :huettenportal].each do |key|
+      context "sac_#{key}_mailing_list_id" do
+        let(:attr) { "sac_#{key}_mailing_list_id" }
 
-      it 'allows value of group mailing_list' do
-        list = Fabricate(:mailing_list, group: group)
-        group.sac_newsletter_mailing_list_id = list.id
-        expect(group).to be_valid
-      end
+        it 'allows empty value' do
+          expect(group).to be_valid
+        end
 
-      it 'does not allow value from other groups' do
-        list = Fabricate(:mailing_list, group: groups(:geschaeftsstelle))
-        group.sac_newsletter_mailing_list_id = list.id
-        expect(group).not_to be_valid
-        expect(group).to have(1).error_on(:sac_newsletter_mailing_list_id)
+        it 'allows value of group mailing_list' do
+          list = Fabricate(:mailing_list, group: group)
+          group.send("#{attr}=", list.id)
+          expect(group).to be_valid
+        end
+
+        it 'does not allow value from other groups' do
+          list = Fabricate(:mailing_list, group: groups(:geschaeftsstelle))
+          group.send("#{attr}=", list.id)
+          expect(group).not_to be_valid
+          expect(group).to have(1).error_on(attr)
+        end
       end
     end
 


### PR DESCRIPTION
refs #504

@codez Die zwei Attribute 

-  "Die Alpen Abo ID" / `sac_magazine_mailing_list_id`
- "SAC Magazin Abo ID" / `sac_magazin_mailing_list_id`

sind sehr nah beisammen, wäre nicht "Die Alpen Abo ID" / `sac_alps_mailing_list_id` naheliegender?