### PR TITLE
Change digital_correspondence to correspondence enum field

### DIFF
--- a/app/helpers/sac_cas/people_helper.rb
+++ b/app/helpers/sac_cas/people_helper.rb
@@ -6,11 +6,6 @@
 #  https://github.com/hitobito/hitobito_sac_cas
 
 module SacCas::PeopleHelper
-  def format_person_digital_correspondence(entry)
-    key = entry.digital_correspondence ? :digital : :print
-    t(:"people.fields_sac_cas.digital_correspondence.#{key}")
-  end
-
   def format_person_sac_family_main_person(person)
     main_person = person.sac_family.main_person
 

--- a/app/models/sac_cas/person.rb
+++ b/app/models/sac_cas/person.rb
@@ -10,6 +10,8 @@ module SacCas::Person
   extend ActiveSupport::Concern
 
   included do
+    CORRESPONDENCES = ['digital', 'print']
+
     Person::LANGUAGES.delete(:en)
 
     devise_login_id_attrs << :membership_number
@@ -24,7 +26,9 @@ module SacCas::Person
     alias_attribute :membership_number, :id
     alias_attribute :navision_id, :id
 
-    attribute :digital_correspondence, :boolean
+    i18n_enum :correspondence, CORRESPONDENCES
+    i18n_setter :correspondence, CORRESPONDENCES
+
     before_save :set_digital_correspondence, if: :password_initialized?
 
     scope :with_membership_years, lambda { |selects = 'people.*'|
@@ -44,7 +48,7 @@ module SacCas::Person
   end
 
   def set_digital_correspondence
-    self.digital_correspondence = true
+    self.correspondence = 'digital'
   end
 
   def password_initialized?

--- a/app/views/people/_details_sac_cas.html.haml
+++ b/app/views/people/_details_sac_cas.html.haml
@@ -3,7 +3,7 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_sac_cas.
 
-= render_attrs(entry, :digital_correspondence)
+= render_attrs(entry, :correspondence)
 - if entry.family_id.present?
   = render_attrs(entry, :family_id, :sac_family_main_person)
 - if entry.sac_membership_anytime?

--- a/app/views/people/_fields_sac_cas.html.haml
+++ b/app/views/people/_fields_sac_cas.html.haml
@@ -1,3 +1,3 @@
-= f.labeled(:digital_correspondence) do
-  = f.inline_radio_button(:digital_correspondence, true, t('.digital_correspondence.digital'))
-  = f.inline_radio_button(:digital_correspondence, false, t('.digital_correspondence.print'))
+= f.labeled(:correspondence) do
+  - SacCas::Person::CORRESPONDENCES.each do |key|
+    = f.inline_radio_button(:correspondence, key, t("activerecord.attributes.person.correspondences.#{key}") )

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -170,9 +170,12 @@ de:
         created_at: Erstellt
         updated_at: Geändert
       person:
-        digital_correspondence: Mitgliederausweis & Rechnungsstellung
+        correspondence: Mitgliederausweis & Rechnungsstellung
         family_id: Familien ID
         sac_family_main_person: Rechnungen an (Familie)
+        correspondences:
+          digital: Digital
+          print: Physisch
         genders:
           _nil: andere
         membership_years: Anzahl Mitglieder-Jahre
@@ -617,11 +620,6 @@ de:
           <a target="blank" href="https://www.sac-cas.ch/de/der-sac/sektionen">https://www.sac-cas.ch/de/der-sac/sektionen</a>'
 
   people:
-    fields_sac_cas:
-      digital_correspondence:
-        digital: Digital
-        print: Physisch
-
     neuanmeldungen:
       multiselect_actions:
         accept: Übernehmen

--- a/db/migrate/20240514093001_change_people_correspondence_to_enum.rb
+++ b/db/migrate/20240514093001_change_people_correspondence_to_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class ChangePeopleCorrespondenceToEnum < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :people, :digital_correspondence
+    add_column :people, :correspondence, :string, null: false, default: 'digital'
+  end
+end

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -119,7 +119,7 @@ module HitobitoSacCas
       Groups::SelfInscriptionController.prepend SacCas::Groups::SelfInscriptionController
       Groups::SelfRegistrationController.prepend SacCas::Groups::SelfRegistrationController
       MailingListsController.prepend SacCas::MailingListsController
-      PeopleController.permitted_attrs << :digital_correspondence
+      PeopleController.permitted_attrs << :correspondence
       PeopleController.prepend SacCas::PeopleController
       PeopleManagersController.prepend SacCas::PeopleManagersController
       Person::HistoryController.prepend SacCas::Person::HistoryController

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -149,31 +149,31 @@ describe Person do
     end
   end
 
-  describe 'digital_correspondence' do
-    it 'gets set to true when password is first set' do
+  describe 'correspondence' do
+    it 'gets set to digital when password is first set' do
       password = 'verysafepasswordfortesting'
-      person = Fabricate(:person, digital_correspondence: false)
-      expect(person.digital_correspondence).to eq(false)
+      person = Fabricate(:person, correspondence: 'print')
+      expect(person.correspondence).to eq('print')
 
       person.password = person.password_confirmation = password
       person.save!
 
-      expect(person.digital_correspondence).to eq(true)
+      expect(person.correspondence).to eq('digital')
     end
 
     it 'does not set to true when password is updated' do
       password = 'verysafepasswordfortesting'
       person = Fabricate(:person, password: password, password_confirmation: password)
-      expect(person.digital_correspondence).to eq(true)
+      expect(person.correspondence).to eq('digital')
 
-      person.update!(digital_correspondence: false)
+      person.update!(correspondence: 'print')
 
-      expect(person.digital_correspondence).to eq(false)
+      expect(person.correspondence).to eq('print')
 
       person.password = person.password_confirmation = 'updatedpasswordalsoverysafeyes'
       person.save!
 
-      expect(person.digital_correspondence).to eq(false)
+      expect(person.correspondence).to eq('print')
     end
   end
 end


### PR DESCRIPTION
Refs: hitobito/hitobito_sac_cas#485

Auslöser war, dass das Flag im Log unverständlich angezeigt wurde: https://github.com/hitobito/hitobito_sac_cas/issues/485#issuecomment-2096413426
Als Lösung darauf wollte ich lieber nicht im PaperTrail decorator herumbasteln sondern fand es leichter das ganze einfach auf ein `i18n_enum` umzubauen. Das ist auch so mit dem Lead BA/DEV abgesprochen.
Hier wird das Flag jetzt nicht korrekt migriert, ist aber glaube ich auch nicht nötig, da das Ticket ja sowieso nicht abgeschlossen war.