### PR TITLE
Feature/sac 428 custom OIDC claims

### DIFF
--- a/app/domain/sac_cas.rb
+++ b/app/domain/sac_cas.rb
@@ -38,4 +38,10 @@ module SacCas
   NEUANMELDUNG_ROLES = (NEUANMELDUNG_HAUPTSEKTION_ROLES + NEUANMELDUNG_ZUSATZSEKTION_ROLES).freeze
 
   NEWSLETTER_MAILING_LIST_INTERNAL_KEY = 'sac_newsletter'
+
+  def main_phone_label
+    Settings.phone_number.predefined_labels.find { |l| l =~ /Haupt/ }
+  end
+
+  module_function :main_phone_label
 end

--- a/app/domain/sac_cas/oidc_claim_setup.rb
+++ b/app/domain/sac_cas/oidc_claim_setup.rb
@@ -33,7 +33,7 @@ module SacCas::OidcClaimSetup
     super
 
     add_claim(:picture_url, scope: [:name, :with_roles])
-    add_claim(:phone_number, scope: [:name, :with_roles])
+    add_claim(:phone, scope: [:name, :with_roles])
 
     add_claim(:membership_years, scope: :with_roles)
     add_claim(:user_groups, scope: :with_groups)
@@ -45,7 +45,7 @@ module SacCas::OidcClaimSetup
     owner.decorate.picture_full_url
   end
 
-  def phone_number(owner)
+  def phone(owner)
     owner.phone_numbers.order(:id).find_by(label: PHONE_NUMBER_LABEL)&.number
   end
 

--- a/app/domain/sac_cas/oidc_claim_setup.rb
+++ b/app/domain/sac_cas/oidc_claim_setup.rb
@@ -9,7 +9,6 @@ module SacCas::OidcClaimSetup
 
   extend ActiveSupport::Concern
 
-  PHONE_NUMBER_LABEL = 'Haupt-Telefonnummer'.freeze
   INFERRED_ROLE_LABLES = {
     section_functionary: Group::SektionsFunktionaere.roles,
     section_president: [Group::SektionsFunktionaere::Praesidium],
@@ -36,7 +35,7 @@ module SacCas::OidcClaimSetup
     add_claim(:phone, scope: [:name, :with_roles])
 
     add_claim(:membership_years, scope: :with_roles)
-    add_claim(:user_groups, scope: :with_groups)
+    add_claim(:user_groups, scope: :user_groups)
   end
 
   private
@@ -46,7 +45,7 @@ module SacCas::OidcClaimSetup
   end
 
   def phone(owner)
-    owner.phone_numbers.order(:id).find_by(label: PHONE_NUMBER_LABEL)&.number
+    owner.phone_numbers.order(:id).find_by(label: SacCas.main_phone_label)&.number
   end
 
   def membership_years(owner)

--- a/app/domain/sac_cas/oidc_claim_setup.rb
+++ b/app/domain/sac_cas/oidc_claim_setup.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+module SacCas::OidcClaimSetup
+
+  extend ActiveSupport::Concern
+
+  PHONE_NUMBER_LABEL = 'Haupt-Telefonnummer'.freeze
+  INFERRED_ROLE_LABLES = {
+    section_functionary: Group::SektionsFunktionaere.roles,
+    section_president: [Group::SektionsFunktionaere::Praesidium],
+    SAC_employee: Group::Geschaeftsstelle.roles,
+    SAC_management: Group::Geschaeftsleitung.roles,
+    SAC_member: [Group::SektionsMitglieder::Mitglied],
+    SAC_member_additional: [Group::SektionsMitglieder::MitgliedZusatzsektion],
+    SAC_central_board_member: Group::Zentralvorstand.roles,
+    SAC_commission_member: Group::Kommission.roles,
+    SAC_tourenportal_subscriber: Group::AboTourenPortal.roles,
+    section_commission_member: Group::SektionsKommission.roles,
+    huts_functionary: Group::SektionsHuettenkommission.roles,
+    tourenportal_author: [Group::AboTourenPortal::Autor],
+    tourenportal_community: [Group::AboTourenPortal::Community],
+    tourenportal_administrator: [Group::AboTourenPortal::Admin],
+    magazin_subscriber: Group::AboMagazin.roles,
+    section_tour_functionary: Group::SektionsTourenkommission.roles,
+  }
+
+  def run
+    super
+
+    add_claim(:picture_url, scope: [:name, :with_roles])
+    add_claim(:phone_number, scope: [:name, :with_roles])
+
+    add_claim(:membership_years, scope: :with_roles)
+    add_claim(:user_groups, scope: :with_groups)
+  end
+
+  private
+
+  def picture_url(owner)
+    owner.decorate.picture_full_url
+  end
+
+  def phone_number(owner)
+    owner.phone_numbers.order(:id).find_by(label: PHONE_NUMBER_LABEL)&.number
+  end
+
+  def membership_years(owner)
+    Person.with_membership_years.find_by(id: owner.id).membership_years
+  end
+
+  def user_groups(owner)
+    inferred_role_strings(owner) + formatted_active_roles(owner)
+  end
+
+  def inferred_role_strings(owner)
+    INFERRED_ROLE_LABLES.select do |_, roles|
+      (owner.roles.map(&:class) & roles).any?
+    end.keys.map(&:to_s)
+  end
+
+  def formatted_active_roles(owner)
+    owner.roles.map { |r| "#{r.type}##{r.group_id}" }
+  end
+end

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -625,6 +625,10 @@ de:
       form:
         login_identity: Haupt‑E‑Mail / Mitglied‑Nr
 
+  doorkeeper:
+    scopes:
+      with_groups: Lesen deiner Gruppen, Rollen und berechneter Felder.
+
   dropdown/people_export:
     recipients: Empfänger
 

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -627,7 +627,7 @@ de:
 
   doorkeeper:
     scopes:
-      with_groups: Lesen deiner Gruppen, Rollen und berechneter Felder.
+      user_groups: Lesen deiner Gruppen, Rollen und berechneter Felder.
 
   dropdown/people_export:
     recipients: Empfänger

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -180,7 +180,7 @@ module HitobitoSacCas
     end
 
     initializer 'sac_cas.append_doorkeeper_scope' do |_app|
-      Doorkeeper.configuration.scopes.add "with_groups"
+      Doorkeeper.configuration.scopes.add "user_groups"
     end
 
     private

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -82,6 +82,7 @@ module HitobitoSacCas
       Event::ParticipationDecorator.prepend SacCas::Event::ParticipationDecorator
 
       ## Domain
+      OidcClaimSetup.prepend SacCas::OidcClaimSetup
       SearchStrategies::SqlConditionBuilder.matchers.merge!(
         'people.id' => SearchStrategies::SqlConditionBuilder::IdMatcher,
         'people.birthday' => SearchStrategies::SqlConditionBuilder::BirthdayMatcher
@@ -178,26 +179,8 @@ module HitobitoSacCas
       end
     end
 
-    initializer 'sac_cas.add_oidc_claims' do |_app|
-      Doorkeeper::OpenidConnect.configuration.claims[:picture_url] =
-        Doorkeeper::OpenidConnect::Claims::NormalClaim.new(
-          name: :picture_url,
-          scope: :name,
-          response: [:user_info],
-          generator: proc do |resource_owner|
-            resource_owner.decorate.picture_full_url
-          end
-        )
-
-      Doorkeeper::OpenidConnect.configuration.claims[:with_roles_picture_url] =
-        Doorkeeper::OpenidConnect::Claims::NormalClaim.new(
-          name: :picture_url,
-          scope: :with_roles,
-          response: [:user_info],
-          generator: proc do |resource_owner|
-            resource_owner.decorate.picture_full_url
-          end
-        )
+    initializer 'sac_cas.append_doorkeeper_scope' do |_app|
+      Doorkeeper.configuration.scopes.add "with_groups"
     end
 
     private

--- a/spec/controllers/oauth/userinfo_controller_spec.rb
+++ b/spec/controllers/oauth/userinfo_controller_spec.rb
@@ -32,7 +32,7 @@ describe Doorkeeper::OpenidConnect::UserinfoController do
           zip_code: user.zip_code,
           town: user.town,
           country: user.country,
-          phone_number: nil,
+          phone: nil,
           picture_url: /\/packs-test\/media\/images\/profile-.*\.svg/,
         }.deep_stringify_keys)
       end
@@ -63,7 +63,7 @@ describe Doorkeeper::OpenidConnect::UserinfoController do
           birthday: user.birthday.to_s.presence,
           primary_group_id: user.primary_group_id,
           language: user.language,
-          phone_number: nil,
+          phone: nil,
           membership_years: 0,
           picture_url: /\/packs-test\/media\/images\/profile-.*\.svg/,
           roles: [
@@ -81,10 +81,10 @@ describe Doorkeeper::OpenidConnect::UserinfoController do
       end
 
     end
-    context 'with with_groups scope' do
+    context 'with user_groups scope' do
       let(:token) do
         app.access_tokens.create!(resource_owner_id: user.id,
-                                  scopes: 'openid with_groups', expires_in: 2.hours)
+                                  scopes: 'openid user_groups', expires_in: 2.hours)
       end
 
       it 'has user_groups key' do

--- a/spec/domain/oidc_claim_setup_spec.rb
+++ b/spec/domain/oidc_claim_setup_spec.rb
@@ -22,8 +22,8 @@ describe OidcClaimSetup do
       end
 
       it 'returns first number with matching label' do
-        owner.phone_numbers.create!(label: 'Haupt-Telefonnummer', number: '0791234560')
-        owner.phone_numbers.create!(label: 'Haupt-Telefonnummer', number: '0791234561')
+        owner.phone_numbers.create!(label: 'Haupt-Telefon', number: '0791234560')
+        owner.phone_numbers.create!(label: 'Haupt-Telefon', number: '0791234561')
         expect(claims[:phone]).to eq '+41 79 123 45 60'
       end
     end
@@ -42,7 +42,7 @@ describe OidcClaimSetup do
   context 'with_roles' do
     let(:scope) { :with_roles }
 
-    describe 'membership_years'do
+    describe 'membership_years' do
       it 'is blank when no matching number exists' do
         expect(claim_keys).to include('membership_years')
       end
@@ -54,9 +54,9 @@ describe OidcClaimSetup do
     it_behaves_like 'shared claims'
   end
 
-  context 'with_groups' do
+  context 'user_groups' do
     let(:role) { roles(:admin) }
-    let(:scope) { :with_groups }
+    let(:scope) { :user_groups }
     let(:user_groups) { claims[:user_groups] }
 
     def create_role(key, role)

--- a/spec/domain/oidc_claim_setup_spec.rb
+++ b/spec/domain/oidc_claim_setup_spec.rb
@@ -16,15 +16,15 @@ describe OidcClaimSetup do
   subject(:claims) { Doorkeeper::OpenidConnect::ClaimsBuilder.generate(token, response) }
 
   shared_examples 'shared claims' do
-    describe 'phone_number' do
+    describe 'phone' do
       it 'is blank when no matching number exists' do
-        expect(claim_keys).to include('phone_number')
+        expect(claim_keys).to include('phone')
       end
 
       it 'returns first number with matching label' do
         owner.phone_numbers.create!(label: 'Haupt-Telefonnummer', number: '0791234560')
         owner.phone_numbers.create!(label: 'Haupt-Telefonnummer', number: '0791234561')
-        expect(claims[:phone_number]).to eq '+41 79 123 45 60'
+        expect(claims[:phone]).to eq '+41 79 123 45 60'
       end
     end
   end
@@ -127,7 +127,7 @@ describe OidcClaimSetup do
     end
 
     it 'includes huts_functionary key when matching role exists' do
-      group = Fabricate(Group::SektionsHuettenkommission.sti_name, parent: groups(:bluemlisalp))
+      group = Fabricate(Group::SektionsHuettenkommission.sti_name, parent: groups(:bluemlisalp_funktionaere))
       create_role(group, 'Huettenobmann')
       expect(user_groups).to include 'huts_functionary'
     end

--- a/spec/domain/oidc_claim_setup_spec.rb
+++ b/spec/domain/oidc_claim_setup_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require 'spec_helper'
+
+describe OidcClaimSetup do
+  let(:owner) { people(:admin) }
+  let(:response) { :user_info }
+  let(:token) { Doorkeeper::AccessToken.new(resource_owner_id: owner.id, scopes: scope) }
+  let(:claim_keys) { claims.stringify_keys.keys }
+
+  subject(:claims) { Doorkeeper::OpenidConnect::ClaimsBuilder.generate(token, response) }
+
+  shared_examples 'shared claims' do
+    describe 'phone_number' do
+      it 'is blank when no matching number exists' do
+        expect(claim_keys).to include('phone_number')
+      end
+
+      it 'returns first number with matching label' do
+        owner.phone_numbers.create!(label: 'Haupt-Telefonnummer', number: '0791234560')
+        owner.phone_numbers.create!(label: 'Haupt-Telefonnummer', number: '0791234561')
+        expect(claims[:phone_number]).to eq '+41 79 123 45 60'
+      end
+    end
+  end
+
+  context 'name' do
+    let(:scope) { :name }
+
+    it 'picture_url is present' do
+      expect(claims[:picture_url]).to eq owner.decorate.picture_full_url
+    end
+
+    it_behaves_like 'shared claims'
+  end
+
+  context 'with_roles' do
+    let(:scope) { :with_roles }
+
+    describe 'membership_years'do
+      it 'is blank when no matching number exists' do
+        expect(claim_keys).to include('membership_years')
+      end
+
+      it 'is blank when no matching number exists' do
+        expect(claims[:membership_years]).to eq 0
+      end
+    end
+    it_behaves_like 'shared claims'
+  end
+
+  context 'with_groups' do
+    let(:role) { roles(:admin) }
+    let(:scope) { :with_groups }
+    let(:user_groups) { claims[:user_groups] }
+
+    def create_role(key, role)
+      group = key.is_a?(Group) ? key : groups(key)
+      role_type = group.class.const_get(role)
+      Fabricate(role_type.sti_name, group: group, person: owner)
+    end
+
+    it 'includes SAC_employee key when matching role exists' do
+      expect(user_groups).to include 'SAC_employee'
+      expect(user_groups).to include 'Group::Geschaeftsstelle::Admin#384133472'
+    end
+
+    it 'includes section_functionary key when matching role exists' do
+      role = create_role(:bluemlisalp_funktionaere, 'AdministrationReadOnly')
+      expect(user_groups).to include "section_functionary"
+      expect(user_groups).to include "Group::Geschaeftsstelle::Admin#384133472"
+      expect(user_groups).to include format('%s#%d' % [role.type, role.group_id])
+    end
+
+    it 'includes section_president key when matching role exists' do
+      role = create_role(:bluemlisalp_funktionaere, 'Praesidium')
+      expect(user_groups).to include 'section_president'
+    end
+
+    it 'includes SAC_management key when matching role exists' do
+      group = Fabricate(Group::Geschaeftsleitung.sti_name, parent: groups(:root))
+
+      role = create_role(group, 'Ressortleitung')
+      expect(user_groups).to include 'SAC_management'
+    end
+
+    it 'includes SAC_member key when matching role exists' do
+      role = create_role(:bluemlisalp_mitglieder, 'Mitglied')
+      expect(user_groups).to include 'SAC_member'
+      expect(user_groups).not_to include 'SAC_member_additional'
+    end
+
+    it 'includes SAC_member key when matching role exists' do
+      create_role(:bluemlisalp_mitglieder, 'Mitglied')
+      role = create_role(:matterhorn_mitglieder, 'MitgliedZusatzsektion')
+      expect(user_groups).to include 'SAC_member'
+      expect(user_groups).to include 'SAC_member_additional'
+    end
+
+    it 'includes SAC_central_board_member key when matching role exists' do
+      group = Fabricate(Group::Zentralvorstand.sti_name, parent: groups(:root))
+      create_role(group, 'Praesidium')
+      expect(user_groups).to include 'SAC_central_board_member'
+    end
+
+    it 'includes SAC_central_board_member key when matching role exists' do
+      group = Fabricate(Group::Kommission.sti_name, parent: groups(:root))
+      create_role(group, 'Praesidium')
+      expect(user_groups).to include 'SAC_commission_member'
+    end
+
+    it 'includes SAC_tourenportal_subscriber key when matching role exists' do
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      create_role(group, 'Autor')
+      expect(user_groups).to include 'SAC_tourenportal_subscriber'
+    end
+
+    it 'includes section_commission_member key when matching role exists' do
+      group = Fabricate(Group::SektionsKommission.sti_name, parent: groups(:bluemlisalp))
+      create_role(group, 'Mitglied')
+      expect(user_groups).to include 'section_commission_member'
+    end
+
+    it 'includes huts_functionary key when matching role exists' do
+      group = Fabricate(Group::SektionsHuettenkommission.sti_name, parent: groups(:bluemlisalp))
+      create_role(group, 'Huettenobmann')
+      expect(user_groups).to include 'huts_functionary'
+    end
+
+    it 'includes tourenportal_author key when matching role exists' do
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      create_role(group, 'Autor')
+      expect(user_groups).to include 'tourenportal_author'
+    end
+
+    it 'includes tourenportal_community key when matching role exists' do
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      create_role(group, 'Community')
+      expect(user_groups).to include 'tourenportal_community'
+    end
+
+    it 'includes tourenportal_community key when matching role exists' do
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      create_role(group, 'Community')
+      expect(user_groups).to include 'tourenportal_community'
+    end
+
+    it 'includes tourenportal_administrator key when matching role exists' do
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      create_role(group, 'Admin')
+      expect(user_groups).to include 'tourenportal_administrator'
+    end
+
+    it 'includes magazin_subscriber key when matching role exists' do
+      group = Fabricate(Group::AboMagazin.sti_name, parent: groups(:abonnenten))
+      create_role(group, 'Andere')
+      expect(user_groups).to include 'magazin_subscriber'
+    end
+
+    it 'includes section_tour_functionary key when matching role exists' do
+      create_role(:bluemlisalp_ortsgruppe_ausserberg_tourenkommission, 'JoChef')
+      expect(user_groups).to include 'section_tour_functionary'
+    end
+  end
+end

--- a/spec/requests/oauth_profile_spec.rb
+++ b/spec/requests/oauth_profile_spec.rb
@@ -10,75 +10,100 @@ require "spec_helper"
 RSpec.describe 'GET oauth/profile', type: :request do
   let(:application) { Fabricate(:application) }
   let(:user)        { people(:mitglied) }
+  let(:json) { JSON.parse(response.body) }
+  let(:token)  {
+    Fabricate(:access_token, application: application, scopes: "name #{scope}",
+              resource_owner_id: user.id ) }
 
-  context 'with all scopes in token' do
-    let(:token)  { Fabricate(:access_token, application: application, scopes: 'email name with_roles', resource_owner_id: user.id ) }
 
-    context 'with scope "name" in request' do
-      it 'succeeds' do
-        get '/oauth/profile', headers: { 'Authorization': 'Bearer ' + token.token, 'X-Scope': 'name' }
 
-        expect(response).to have_http_status(:ok)
-        expect(response.content_type).to eq('application/json; charset=utf-8')
-        json = JSON.parse(response.body)
-        expect(json).to match({
-                                id: user.id,
-                                email: user.email,
-                                first_name: user.first_name,
-                                last_name: user.last_name,
-                                nickname: user.nickname,
-                                address: user.address,
-                                zip_code: user.zip_code,
-                                town: user.town,
-                                country: user.country,
-                                picture_url: /\/packs-test\/media\/images\/profile-.*\.svg/,
-                              }.deep_stringify_keys)
-      end
-    end
+  def make_request(skip_checks: true)
+    get '/oauth/profile', headers: { 'Authorization': 'Bearer ' + token.token, 'X-Scope': scope }
+    return if skip_checks
 
-    context 'with scope "with_roles" in request' do
-      it 'succeeds' do
-        get '/oauth/profile', headers: { 'Authorization': 'Bearer ' + token.token, 'X-Scope': 'with_roles' }
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to eq('application/json; charset=utf-8')
+  end
 
-        expect(response).to have_http_status(:ok)
-        expect(response.content_type).to eq('application/json; charset=utf-8')
-        json = JSON.parse(response.body)
-        expect(json).to match({
-                             id: user.id,
-                             first_name: user.first_name,
-                             last_name: user.last_name,
-                             nickname: user.nickname,
-                             company_name: user.company_name,
-                             company: user.company,
-                             email: user.email,
-                             address: user.address,
-                             zip_code: user.zip_code,
-                             town: user.town,
-                             country: user.country,
-                             gender: user.gender,
-                             birthday: user.birthday.to_s.presence,
-                             primary_group_id: user.primary_group_id,
-                             language: user.language,
-                             picture_url: /\/packs-test\/media\/images\/profile-.*\.svg/,
-                             roles: [{
-                               group_id: user.roles.first.group_id,
-                               group_name: user.roles.first.group.name,
-                               role: 'Group::SektionsMitglieder::Mitglied',
-                               role_class: 'Group::SektionsMitglieder::Mitglied',
-                               role_name: 'Mitglied (Stammsektion)',
-                               permissions: [],
-                               layer_group_id: user.roles.first.group.layer_group_id
-                             },{
-                               group_id: user.roles.second.group_id,
-                               group_name: user.roles.second.group.name,
-                               role: 'Group::SektionsMitglieder::MitgliedZusatzsektion',
-                               role_class: 'Group::SektionsMitglieder::MitgliedZusatzsektion',
-                               role_name: 'Mitglied (Zusatzsektion)',
-                               permissions: [],
-                               layer_group_id: user.roles.second.group.layer_group_id
-                             }]
-                           }.deep_stringify_keys)
-      end
+  context 'with scope "name" in request' do
+    let(:scope) { :name }
+
+    it 'succeeds' do
+      make_request
+      expect(json).to match({
+        id: user.id,
+        email: user.email,
+        first_name: user.first_name,
+        last_name: user.last_name,
+        nickname: user.nickname,
+        address: user.address,
+        zip_code: user.zip_code,
+        town: user.town,
+        country: user.country,
+        picture_url: /\/packs-test\/media\/images\/profile-.*\.svg/,
+        phone_number: nil,
+      }.deep_stringify_keys)
     end
   end
+
+  context 'with scope "with_roles" in request' do
+    let(:scope) { 'with_roles' }
+
+    it 'succeeds' do
+      make_request
+      expect(json).to match({
+        id: user.id,
+        first_name: user.first_name,
+        last_name: user.last_name,
+        nickname: user.nickname,
+        company_name: user.company_name,
+        company: user.company,
+        email: user.email,
+        address: user.address,
+        zip_code: user.zip_code,
+        town: user.town,
+        country: user.country,
+        gender: user.gender,
+        birthday: user.birthday.to_s.presence,
+        primary_group_id: user.primary_group_id,
+        language: user.language,
+        picture_url: /\/packs-test\/media\/images\/profile-.*\.svg/,
+        phone_number: nil,
+        membership_years: 1,
+        roles: [{
+          group_id: user.roles.first.group_id,
+          group_name: user.roles.first.group.name,
+          role: 'Group::SektionsMitglieder::Mitglied',
+          role_class: 'Group::SektionsMitglieder::Mitglied',
+          role_name: 'Mitglied (Stammsektion)',
+          permissions: [],
+          layer_group_id: user.roles.first.group.layer_group_id
+        },{
+          group_id: user.roles.second.group_id,
+          group_name: user.roles.second.group.name,
+          role: 'Group::SektionsMitglieder::MitgliedZusatzsektion',
+          role_class: 'Group::SektionsMitglieder::MitgliedZusatzsektion',
+          role_name: 'Mitglied (Zusatzsektion)',
+          permissions: [],
+          layer_group_id: user.roles.second.group.layer_group_id
+        }]
+      }.deep_stringify_keys)
+    end
+  end
+
+  context 'with scope "with_groups" in request' do
+    let(:scope) { 'with_groups' }
+
+    it 'succeeds' do
+      make_request
+      expect(json['user_groups']).to include 'SAC_member'
+    end
+
+    it 'is forbidden to be used without names scope on token' do
+      token.update!(scopes: 'with_groups')
+      make_request
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
 end

--- a/spec/requests/oauth_profile_spec.rb
+++ b/spec/requests/oauth_profile_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'GET oauth/profile', type: :request do
         town: user.town,
         country: user.country,
         picture_url: /\/packs-test\/media\/images\/profile-.*\.svg/,
-        phone_number: nil,
+        phone: nil,
       }.deep_stringify_keys)
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe 'GET oauth/profile', type: :request do
         primary_group_id: user.primary_group_id,
         language: user.language,
         picture_url: /\/packs-test\/media\/images\/profile-.*\.svg/,
-        phone_number: nil,
+        phone: nil,
         membership_years: 1,
         roles: [{
           group_id: user.roles.first.group_id,
@@ -91,8 +91,8 @@ RSpec.describe 'GET oauth/profile', type: :request do
     end
   end
 
-  context 'with scope "with_groups" in request' do
-    let(:scope) { 'with_groups' }
+  context 'with scope "user_groups" in request' do
+    let(:scope) { 'user_groups' }
 
     it 'succeeds' do
       make_request
@@ -100,7 +100,7 @@ RSpec.describe 'GET oauth/profile', type: :request do
     end
 
     it 'is forbidden to be used without names scope on token' do
-      token.update!(scopes: 'with_groups')
+      token.update!(scopes: 'user_groups')
       make_request
       expect(response).to have_http_status(:forbidden)
     end


### PR DESCRIPTION
Mir ist noch nicht ganz klar, warum in `spec/requests/oauth_profile_spec.rb` der `with_groups` scope nicht alleine funktioniert (sonder nur in kombination mit name). Weist da jemand was? Sollen wir das noch vertieft anschauen? 