### PR TITLE
Feature/553 sektion layer and below full ability constraints for qualifications and external trainings

### DIFF
--- a/app/abilities/external_training_ability.rb
+++ b/app/abilities/external_training_ability.rb
@@ -24,6 +24,8 @@ class ExternalTrainingAbility < AbilityDsl::Base
   end
 
   def in_same_layer_or_below_unless_sektions_mitgliederverwaltung
-    in_same_layer_or_below && !role_type?(Group::SektionsFunktionaere::Mitgliederverwaltung)
+    without_role(Group::SektionsFunktionaere::Mitgliederverwaltung) do
+      in_same_layer_or_below
+    end
   end
 end

--- a/app/abilities/external_training_ability.rb
+++ b/app/abilities/external_training_ability.rb
@@ -7,10 +7,13 @@
 
 class ExternalTrainingAbility < AbilityDsl::Base
   include AbilityDsl::Constraints::Person
+  include SacCas::AbilityConstraints
 
   on(ExternalTraining) do
     permission(:layer_full).may(:create, :destroy).in_same_layer
-    permission(:layer_and_below_full).may(:create, :destroy).in_same_layer_or_below
+    permission(:layer_and_below_full).may(:create, :destroy)
+      .in_same_layer_or_below_unless_sektions_mitgliederverwaltung
+
 
     permission(:group_full).may(:create, :destroy).in_same_group
     permission(:group_and_below_full).may(:create, :destroy).in_same_group_or_below
@@ -18,5 +21,9 @@ class ExternalTrainingAbility < AbilityDsl::Base
 
   def person
     subject.person
+  end
+
+  def in_same_layer_or_below_unless_sektions_mitgliederverwaltung
+    in_same_layer_or_below && !role_type?(Group::SektionsFunktionaere::Mitgliederverwaltung)
   end
 end

--- a/app/abilities/sac_cas/ability_constraints.rb
+++ b/app/abilities/sac_cas/ability_constraints.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+module SacCas::AbilityConstraints
+  extend ActiveSupport::Concern
+
+  def unless_sektions_mitgliederverwaltung
+    user_context.user.roles.none? { |r| r.is_a?(Group::SektionsFunktionaere::Mitgliederverwaltung) }
+  end
+end
+

--- a/app/abilities/sac_cas/ability_dsl/base.rb
+++ b/app/abilities/sac_cas/ability_dsl/base.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module SacCas::AbilityDsl::Base
+  extend ActiveSupport::Concern
+
+  private
+
+  def without_role(role_class)
+    roles = user.roles.reject { |r| r.is_a?(role_class) }
+    person = Person.new { |p| p.roles = roles }
+    previous = @user_context
+    @user_context = AbilityDsl::UserContext.new(person)
+    yield.tap { @user_context = previous }
+  end
+end

--- a/app/abilities/sac_cas/qualification_ability.rb
+++ b/app/abilities/sac_cas/qualification_ability.rb
@@ -17,7 +17,13 @@ module SacCas::QualificationAbility
   included do
     on(Qualification) do
       permission(:any).may(:create, :destroy).for_tourenchef_qualification_as_tourenchef_in_layer
+      permission(:layer_and_below_full).may(:create, :destroy)
+        .in_course_layer_or_below_unless_sektions_mitgliederverwaltung
     end
+  end
+
+  def in_course_layer_or_below_unless_sektions_mitgliederverwaltung
+    in_course_layer_or_below && !role_type?(Group::SektionsFunktionaere::Mitgliederverwaltung)
   end
 
   def for_tourenchef_qualification_as_tourenchef_in_layer

--- a/app/abilities/sac_cas/qualification_ability.rb
+++ b/app/abilities/sac_cas/qualification_ability.rb
@@ -23,7 +23,9 @@ module SacCas::QualificationAbility
   end
 
   def in_course_layer_or_below_unless_sektions_mitgliederverwaltung
-    in_course_layer_or_below && !role_type?(Group::SektionsFunktionaere::Mitgliederverwaltung)
+    without_role(Group::SektionsFunktionaere::Mitgliederverwaltung) do
+      in_course_layer_or_below
+    end
   end
 
   def for_tourenchef_qualification_as_tourenchef_in_layer

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -66,6 +66,7 @@ module HitobitoSacCas
       Ability.store.register ExternalTrainingAbility
       Ability.store.register SacMembershipConfigAbility
       Ability.store.register SacSectionMembershipConfigAbility
+      AbilityDsl::Base.prepend SacCas::AbilityDsl::Base
       PersonAbility.prepend SacCas::PersonAbility
       PersonReadables.prepend SacCas::PersonReadables
       RoleAbility.prepend SacCas::RoleAbility

--- a/spec/abilities/external_training_ability_spec.rb
+++ b/spec/abilities/external_training_ability_spec.rb
@@ -82,6 +82,13 @@ describe ExternalTrainingAbility do
         expect(ability).not_to be_able_to(:create, external_training)
         expect(ability).not_to be_able_to(:destroy, external_training)
       end
+
+      it 'is permitted if has another role with layer_and_below_full' do
+        Fabricate(Group::Geschaeftsstelle::Admin.sti_name, group: groups(:geschaeftsstelle), person: role.person)
+
+        expect(ability).to be_able_to(:create, external_training)
+        expect(ability).to be_able_to(:destroy, external_training)
+      end
     end
   end
 end

--- a/spec/abilities/external_training_ability_spec.rb
+++ b/spec/abilities/external_training_ability_spec.rb
@@ -49,5 +49,40 @@ describe ExternalTrainingAbility do
       end
     end
   end
+
+  describe 'with layer_and_below_full' do
+    let(:person) { Fabricate(Group::SektionsMitglieder::Mitglied.name.to_sym, group: groups(:bluemlisalp_mitglieder)).person }
+
+    def create_funktionaer(role)
+      Fabricate(role.sti_name, group: groups(:bluemlisalp_funktionaere))
+    end
+
+    context 'layer_and_below_full in top layer' do
+      let(:role) { roles(:admin) }
+
+      it 'is permitted to create and destroy' do
+        expect(ability).to be_able_to(:create, external_training)
+        expect(ability).to be_able_to(:destroy, external_training)
+      end
+    end
+
+    describe Group::SektionsFunktionaere::Administration do
+      let(:role) { create_funktionaer(Group::SektionsFunktionaere::Administration) }
+
+      it 'is permitted to create and destroy' do
+        expect(ability).to be_able_to(:create, external_training)
+        expect(ability).to be_able_to(:destroy, external_training)
+      end
+    end
+
+    describe Group::SektionsFunktionaere::Mitgliederverwaltung do
+      let(:role) { create_funktionaer(Group::SektionsFunktionaere::Mitgliederverwaltung) }
+
+      it 'is not permitted to create and destroy' do
+        expect(ability).not_to be_able_to(:create, external_training)
+        expect(ability).not_to be_able_to(:destroy, external_training)
+      end
+    end
+  end
 end
 

--- a/spec/abilities/sac_cas/qualification_ability_spec.rb
+++ b/spec/abilities/sac_cas/qualification_ability_spec.rb
@@ -121,6 +121,11 @@ describe QualificationAbility do
         expect(ability).to be_able_to(:create, qualification)
         expect(ability).to be_able_to(:destroy, qualification)
       end
+
+      it 'is permitted to create and destroy even with Mitgliederverwaltungs role' do
+        expect(ability).to be_able_to(:create, qualification)
+        expect(ability).to be_able_to(:destroy, qualification)
+      end
     end
 
     describe Group::SektionsFunktionaere::Administration do
@@ -138,6 +143,13 @@ describe QualificationAbility do
       it 'is not permitted to create and destroy' do
         expect(ability).not_to be_able_to(:create, qualification)
         expect(ability).not_to be_able_to(:destroy, qualification)
+      end
+
+      it 'is permitted if has another role with layer_and_below_full' do
+        Fabricate(Group::Geschaeftsstelle::Admin.sti_name, group: groups(:geschaeftsstelle), person: person)
+
+        expect(ability).to be_able_to(:create, qualification)
+        expect(ability).to be_able_to(:destroy, qualification)
       end
     end
   end

--- a/spec/abilities/sac_cas/qualification_ability_spec.rb
+++ b/spec/abilities/sac_cas/qualification_ability_spec.rb
@@ -23,6 +23,12 @@ describe QualificationAbility do
 
   subject(:ability) { Ability.new(person) }
 
+  def fabricate_readonly_role(group)
+    Fabricate(Group::SektionsFunktionaere::AdministrationReadOnly.sti_name.to_sym,
+              person: ausserberg_tourenchef,
+              group: group)
+  end
+
   describe 'as tourenchef' do
     context 'regarding qualification_kind with tourenchef_may_edit true' do
       let(:qualification) { Fabricate(:qualification, qualification_kind: tourenchef_may_edit_qualification_kind) }
@@ -99,9 +105,40 @@ describe QualificationAbility do
     end
   end
 
-  def fabricate_readonly_role(group)
-    Fabricate(Group::SektionsFunktionaere::AdministrationReadOnly.sti_name.to_sym,
-              person: ausserberg_tourenchef,
-              group: group)
+  describe 'with layer_and_below_full' do
+    let(:bluemlisalp_mitglied) { people(:mitglied) }
+    let(:qualification_kind) { qualification_kinds(:ski_leader) }
+    let(:qualification) { Fabricate(:qualification, qualification_kind: qualification_kind, person: bluemlisalp_mitglied) }
+
+    def create_funktionaer(role)
+      Fabricate(role.sti_name, group: groups(:bluemlisalp_funktionaere))
+    end
+
+    context 'layer_and_below_full in top layer' do
+      let(:person) { people(:admin) }
+
+      it 'is permitted to create and destroy' do
+        expect(ability).to be_able_to(:create, qualification)
+        expect(ability).to be_able_to(:destroy, qualification)
+      end
+    end
+
+    describe Group::SektionsFunktionaere::Administration do
+      let(:person) { create_funktionaer(Group::SektionsFunktionaere::Administration).person }
+
+      it 'is permitted to create and destroy' do
+        expect(ability).to be_able_to(:create, qualification)
+        expect(ability).to be_able_to(:destroy, qualification)
+      end
+    end
+
+    describe Group::SektionsFunktionaere::Mitgliederverwaltung do
+      let(:person) { create_funktionaer(Group::SektionsFunktionaere::Mitgliederverwaltung).person }
+
+      it 'is not permitted to create and destroy' do
+        expect(ability).not_to be_able_to(:create, qualification)
+        expect(ability).not_to be_able_to(:destroy, qualification)
+      end
+    end
   end
 end

--- a/spec/controllers/external_trainings_controller_spec.rb
+++ b/spec/controllers/external_trainings_controller_spec.rb
@@ -79,18 +79,18 @@ describe ExternalTrainingsController do
 
       context 'as mitglied' do
         let(:funktionaere) { groups(:bluemlisalp_funktionaere) }
-        let(:verwalter) do
-          Fabricate(Group::SektionsFunktionaere::Mitgliederverwaltung.sti_name,
+        let(:funktionaere_admin) do
+          Fabricate(Group::SektionsFunktionaere::Administration.sti_name,
                     group: funktionaere).person
         end
 
         it 'ignores person for which current user has no write permission' do
-          sign_in(verwalter)
-          params[:external_training][:other_people_ids] = [admin.id, verwalter.id]
+          sign_in(funktionaere_admin)
+          params[:external_training][:other_people_ids] = [admin.id, funktionaere_admin.id]
           expect do
             post :create, params: params
           end.to change { ExternalTraining.count }.by(2)
-            .and change { verwalter.external_trainings.count }.by(1)
+            .and change { funktionaere_admin.external_trainings.count }.by(1)
             .and not_change { admin.external_trainings.count }
         end
       end


### PR DESCRIPTION
Geht es hier wirklich um die spezifische Rolle (1) oder soll grundsätzlich nur der Dachverband (2) Qualis und External Trainings bearbeiten dürfen? Der Text lässt beide Interpretationen zu. Mit den aktuellen Permissions gibt es 2 Rollen `(Mitgliederverwaltung: 2FA [:layer_and_below_full], Administration: 2FA [:layer_and_below_full]`) die auf die Beschreibung passen. 

Ich hab das jetzt mal Richtung (2) mit einem general constraint `.if_root_only_or_no_layer_and_below_full_permission` umgesetzt.