### PR TITLE
 EVENTS: Zusätzliche Statuswechsel #583

### DIFF
--- a/app/helpers/dropdown/events/courses/state.rb
+++ b/app/helpers/dropdown/events/courses/state.rb
@@ -33,10 +33,10 @@ module Dropdown::Events::Courses
     end
 
     def label_for_step(step)
-      label_translation_default = template.t(".state_buttons.#{step}")
+      label_translation_default = t(".state_buttons.#{step}")
       if course.state_comes_before?(step, course.state)
-        template.t(".state_back_buttons.#{step}",
-                   default: label_translation_default)
+        t(".state_back_buttons.#{step}",
+          default: label_translation_default)
       else
         label_translation_default
       end

--- a/app/helpers/dropdown/events/courses/state.rb
+++ b/app/helpers/dropdown/events/courses/state.rb
@@ -28,7 +28,17 @@ module Dropdown::Events::Courses
     def init_items
       course.available_states.each do |step|
         link = template.state_group_event_path(template.params[:group_id], course, { state: step })
-        add_item(template.t(".state_buttons.#{step}"), link, method: :put)
+        add_item(label_for_step(step), link, method: :put)
+      end
+    end
+
+    def label_for_step(step)
+      label_translation_default = template.t(".state_buttons.#{step}")
+      if course.state_comes_before?(step, course.state)
+        template.t(".state_back_buttons.#{step}",
+                   default: label_translation_default)
+      else
+        label_translation_default
       end
     end
   end

--- a/app/models/concerns/events/courses/state.rb
+++ b/app/models/concerns/events/courses/state.rb
@@ -31,6 +31,11 @@ module Events::Courses::State
       SAC_COURSE_STATES[state.to_sym]
     end
 
+    def state_comes_before?(state1, state2)
+      states = SAC_COURSE_STATES.keys
+      states.index(state1.to_sym) < states.index(state2.to_sym)
+    end
+
     def assignment_closed?
       state.to_sym == :assignment_closed
     end

--- a/app/models/concerns/events/courses/state.rb
+++ b/app/models/concerns/events/courses/state.rb
@@ -16,8 +16,8 @@ module Events::Courses::State
         application_open: [:application_paused, :created, :canceled],
         application_paused: [:application_open],
         application_closed: [:assignment_closed, :canceled],
-        assignment_closed: [:ready, :canceled],
-        ready: [:closed, :canceled],
+        assignment_closed: [:ready, :application_closed, :canceled],
+        ready: [:closed, :assignment_closed, :canceled],
         canceled: [:application_open],
         closed: [:ready] }.freeze
 

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -773,6 +773,10 @@ de:
         ready: Bereit zur Durchführung
         closed: Abschliessen
         canceled: Absagen
+      state_back_buttons:
+        assignment_closed: Zurück zur Zuteilung
+        application_closed: Zurück zur abgeschlossenen Anmeldung
+
     form_tabs:
       communication: Kommunikation
     general_fields:

--- a/spec/models/event/course_spec.rb
+++ b/spec/models/event/course_spec.rb
@@ -263,12 +263,12 @@ describe Event::Course do
 
     it 'lists available states for state :assignment_closed' do
       expect(course).to receive(:state).and_return(:assignment_closed)
-      expect(course.available_states).to eq([:ready, :canceled])
+      expect(course.available_states).to eq([:ready, :application_closed, :canceled])
     end
 
     it 'lists available states for state :ready' do
       expect(course).to receive(:state).and_return(:ready)
-      expect(course.available_states).to eq([:closed, :canceled])
+      expect(course.available_states).to eq([:closed, :assignment_closed, :canceled])
     end
 
     it 'lists available states for state :canceled' do


### PR DESCRIPTION
fixes #583 

Basically done except:

this is missing the special return text for the buttons. It might be confusing for the user at this state

"Anmeldung abschliessen" instead of "Zurück zur abgeschlossenen Anmeldung"