### PR TITLE
Feature/627 Wizard austritt zusatzsektion

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -56,6 +56,7 @@ Rails/HelperInstanceVariable:
     - 'app/helpers/sac_cas/event/participation_banner.rb'
     - 'app/helpers/sac_cas/event/participation_buttons.rb'
     - 'app/helpers/sheet/memberships/join_zusatzsektion.rb'
+    - 'app/helpers/sheet/memberships/leave_zusatzsektion.rb'
 
 # Offense count: 3
 # Configuration parameters: IgnoreScopes, Include.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,6 +55,7 @@ Rails/HelperInstanceVariable:
     - 'app/helpers/dropdown/people/memberships.rb'
     - 'app/helpers/sac_cas/event/participation_banner.rb'
     - 'app/helpers/sac_cas/event/participation_buttons.rb'
+    - 'app/helpers/sac_cas/roles/terminate_role_link.rb'
     - 'app/helpers/sheet/memberships/join_zusatzsektion.rb'
     - 'app/helpers/sheet/memberships/leave_zusatzsektion.rb'
 

--- a/app/abilities/memberships/leave_zusatzsektion_ability.rb
+++ b/app/abilities/memberships/leave_zusatzsektion_ability.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Memberships
+  class LeaveZusatzsektionAbility < AbilityDsl::Base
+    on(Wizards::Memberships::LeaveZusatzsektion) do
+      permission(:any).may(:create).for_self_if_active_member_or_backoffice
+    end
+
+    def for_self_if_active_member_or_backoffice
+      active_member? && (for_self? || backoffice?)
+    end
+
+    def backoffice?
+      user_context.user.backoffice?
+    end
+
+    def for_self?
+      subject.person == user_context.user
+    end
+
+    def active_member?
+      People::SacMembership.new(subject.person).active?
+    end
+  end
+end

--- a/app/components/sac_cas/steps_component/content_component.rb
+++ b/app/components/sac_cas/steps_component/content_component.rb
@@ -9,11 +9,11 @@ module SacCas::StepsComponent::ContentComponent
   extend ActiveSupport::Concern
 
   # Have not been able to render error messages and block in single fields_for call
-  def fields_for(&)
+  def fields_for(next_text: nil, &)
     partial_name = @partial.split("/").last
     @form.fields_for(partial_name, model) do |form|
       form.error_messages
-    end + @form.fields_for(partial_name, model, &) + bottom_toolbar
+    end + @form.fields_for(partial_name, model, &) + bottom_toolbar(next_text: next_text)
   end
 
   def model
@@ -26,10 +26,10 @@ module SacCas::StepsComponent::ContentComponent
     super
   end
 
-  def bottom_toolbar
+  def bottom_toolbar(next_text: nil)
     content_tag(:div, class: "btn-toolbar allign-with-form") do
       buttons = [
-        next_button
+        next_button(next_text)
       ]
       buttons << back_link if index.positive?
       safe_join(buttons)

--- a/app/components/sac_cas/steps_component/content_component.rb
+++ b/app/components/sac_cas/steps_component/content_component.rb
@@ -9,11 +9,11 @@ module SacCas::StepsComponent::ContentComponent
   extend ActiveSupport::Concern
 
   # Have not been able to render error messages and block in single fields_for call
-  def fields_for(next_text: nil, &)
+  def fields_for(&)
     partial_name = @partial.split("/").last
     @form.fields_for(partial_name, model) do |form|
       form.error_messages
-    end + @form.fields_for(partial_name, model, &) + bottom_toolbar(next_text: next_text)
+    end + @form.fields_for(partial_name, model, &) + bottom_toolbar
   end
 
   def model
@@ -26,11 +26,9 @@ module SacCas::StepsComponent::ContentComponent
     super
   end
 
-  def bottom_toolbar(next_text: nil)
+  def bottom_toolbar
     content_tag(:div, class: "btn-toolbar allign-with-form") do
-      buttons = [
-        next_button(next_text)
-      ]
+      buttons = [next_button]
       buttons << back_link if index.positive?
       safe_join(buttons)
     end

--- a/app/controllers/memberships/leave_zusatzsektions_controller.rb
+++ b/app/controllers/memberships/leave_zusatzsektions_controller.rb
@@ -23,7 +23,7 @@ module Memberships
         person: person,
         role: role,
         current_step: params[:step].to_i,
-        backoffice: person.backoffice?,
+        backoffice: current_user.backoffice?,
         **model_params.to_unsafe_h
       )
     end

--- a/app/controllers/memberships/leave_zusatzsektions_controller.rb
+++ b/app/controllers/memberships/leave_zusatzsektions_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Memberships
+  class LeaveZusatzsektionsController < Wizards::BaseController
+    before_action :wizard, :person, :group, :authorize
+
+    helper_method :group, :person
+    alias_method :entry, :wizard
+
+    private
+
+    def authorize
+      authorize!(:create, wizard)
+    end
+
+    def wizard
+      @wizard ||= model_class.new(
+        person: person,
+        current_step: params[:step].to_i,
+        backoffice: person.backoffice?,
+        **model_params.to_unsafe_h
+      )
+    end
+
+    def model_class
+      Wizards::Memberships::LeaveZusatzsektion
+    end
+
+    def success_message
+      roles_count = wizard.leave_operation.affected_people.count
+      t(".success", group_name: wizard.choose_sektion.group.to_s, count: roles_count)
+    end
+
+    # NOTE: format: :html is required otherwise it is redirect as turbo_stream
+    def redirect_target
+      person_path(person, format: :html)
+    end
+
+    def person
+      @person ||= Person.find(params[:person_id])
+    end
+
+    def group
+      @group ||= Group.find(params[:group_id])
+    end
+  end
+end

--- a/app/controllers/memberships/leave_zusatzsektions_controller.rb
+++ b/app/controllers/memberships/leave_zusatzsektions_controller.rb
@@ -34,7 +34,7 @@ module Memberships
 
     def success_message
       roles_count = wizard.leave_operation.affected_people.count
-      t(".success", group_name: wizard.sektion, count: roles_count)
+      t(".success", group_name: wizard.sektion_name, count: roles_count)
     end
 
     # NOTE: format: :html is required otherwise it is redirect as turbo_stream

--- a/app/controllers/memberships/leave_zusatzsektions_controller.rb
+++ b/app/controllers/memberships/leave_zusatzsektions_controller.rb
@@ -7,7 +7,7 @@
 
 module Memberships
   class LeaveZusatzsektionsController < Wizards::BaseController
-    before_action :wizard, :person, :group, :authorize
+    before_action :wizard, :person, :group, :role, :authorize
 
     helper_method :group, :person
     alias_method :entry, :wizard
@@ -21,6 +21,7 @@ module Memberships
     def wizard
       @wizard ||= model_class.new(
         person: person,
+        role: role,
         current_step: params[:step].to_i,
         backoffice: person.backoffice?,
         **model_params.to_unsafe_h
@@ -33,7 +34,7 @@ module Memberships
 
     def success_message
       roles_count = wizard.leave_operation.affected_people.count
-      t(".success", group_name: wizard.choose_sektion.group.to_s, count: roles_count)
+      t(".success", group_name: wizard.sektion, count: roles_count)
     end
 
     # NOTE: format: :html is required otherwise it is redirect as turbo_stream
@@ -43,6 +44,10 @@ module Memberships
 
     def person
       @person ||= Person.find(params[:person_id])
+    end
+
+    def role
+      @role ||= Role.find(params[:role_id])
     end
 
     def group

--- a/app/helpers/sac_cas/roles/terminate_role_link.rb
+++ b/app/helpers/sac_cas/roles/terminate_role_link.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac
+
+module SacCas::Roles::TerminateRoleLink
+  private
+
+  def render_link
+    if @role.is_a?(Group::SektionsMitglieder::MitgliedZusatzsektion)
+      link_to(t("roles/terminations.global.title"),
+        @view.group_person_role_leave_zusatzsektion_path(
+          role_id: @role.id, group_id: @role.group&.id, person_id: @role.person&.id
+        ),
+        class: "btn btn-xs float-right")
+    else
+      super
+    end
+  end
+end

--- a/app/helpers/sheet/memberships/leave_zusatzsektion.rb
+++ b/app/helpers/sheet/memberships/leave_zusatzsektion.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Sheet::Memberships
+  class LeaveZusatzsektion < Sheet::Base
+    self.parent_sheet = Sheet::Person
+
+    def initialize(*args)
+      super
+      @title = I18n.t(".title", scope: self.class.to_s.underscore)
+    end
+  end
+end

--- a/app/models/memberships/common_api.rb
+++ b/app/models/memberships/common_api.rb
@@ -22,6 +22,10 @@ module Memberships::CommonApi
     save
   end
 
+  def affected_people
+    person.sac_membership.family? ? person.household.people : [person]
+  end
+
   def roles
     @roles ||= affected_people.flat_map { |p| prepare_roles(p) }
   end
@@ -65,9 +69,5 @@ module Memberships::CommonApi
       roles.each { |role| role.save(validate: false) }
       roles.each(&:save!)
     end
-  end
-
-  def affected_people
-    person.sac_membership.family? ? person.household.people : [person]
   end
 end

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -88,8 +88,7 @@ module Wizards::Memberships
     end
 
     def handle_start
-      membership_role = Group::SektionsMitglieder::Mitglied.find_by(person: person)
-      if membership_role&.terminated?
+      if person.sac_membership.terminated?
         Wizards::Steps::MembershipTerminatedInfo.step_name
       elsif mitglied_termination_by_section_only? && !backoffice?
         Wizards::Steps::TerminationNoSelfService.step_name

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -61,12 +61,11 @@ module Wizards::Memberships
     private
 
     def family_membership?
-      !person.household.empty?
+      role.beitragskategorie.family?
     end
 
     def family_main_person?
-      # TODO: Implement
-      false
+      person.sac_family_main_person
     end
 
     def leave_operation_valid?

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -58,11 +58,11 @@ module Wizards::Memberships
       @backoffice
     end
 
-    private
-
     def family_membership?
       role.beitragskategorie.family?
     end
+
+    private
 
     def family_main_person?
       person.sac_family_main_person

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -18,7 +18,7 @@ module Wizards::Memberships
     attr_reader :person, :role
 
     def sektion_name
-      role.group.parent.display_name
+      role.layer_group.display_name
     end
 
     def initialize(current_step: 0, person: nil, role: nil, backoffice: false, **params)

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -57,10 +57,6 @@ module Wizards::Memberships
       role.layer_group.mitglied_termination_by_section_only
     end
 
-    def sac_mitarbeiter?
-      @backoffice
-    end
-
     def family_membership?
       role.beitragskategorie.family?
     end
@@ -100,11 +96,11 @@ module Wizards::Memberships
       membership_role = Group::SektionsMitglieder::Mitglied.find_by(person: person)
       if membership_role&.terminated?
         Wizards::Steps::MembershipTerminatedInfo.step_name
-      elsif mitglied_termination_by_section_only? && !sac_mitarbeiter?
+      elsif mitglied_termination_by_section_only? && !backoffice?
         Wizards::Steps::TerminationNoSelfService.step_name
       elsif family_membership? && !family_main_person?
         Wizards::Steps::LeaveZusatzsektion::AskFamilyMainPerson.step_name
-      elsif sac_mitarbeiter?
+      elsif backoffice?
         Wizards::Steps::TerminationChooseDate.step_name
       else
         Wizards::Steps::LeaveZusatzsektion::Summary.step_name

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -38,6 +38,7 @@ module Wizards::Memberships
     end
 
     def leave_operation
+      # TODO: Add termination_reason_id https://github.com/hitobito/hitobito_sac_cas/issues/718
       @leave_operation ||= Memberships::LeaveZusatzsektion.new(role, terminate_on)
     end
 

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -15,12 +15,17 @@ module Wizards::Memberships
       Wizards::Steps::LeaveZusatzsektion::Summary
     ]
 
-    attr_reader :person, :sektion
+    attr_reader :person, :role
 
-    def initialize(current_step: 0, person: nil, sektion: nil, backoffice: false, **params)
+    # TODO: Rename to sektion_name
+    def sektion
+      role.group.parent.display_name
+    end
+
+    def initialize(current_step: 0, person: nil, role: nil, backoffice: false, **params)
       super(current_step: current_step, **params)
       @person = person
-      @sektion = sektion
+      @role = role
       @backoffice = backoffice
     end
 
@@ -34,7 +39,7 @@ module Wizards::Memberships
     end
 
     def leave_operation
-      @leave_operation ||= Memberships::LeaveZusatzsektion.new(sektion, terminate_on)
+      @leave_operation ||= Memberships::LeaveZusatzsektion.new(role, terminate_on)
     end
 
     def backoffice?
@@ -42,7 +47,7 @@ module Wizards::Memberships
     end
 
     def terminate_on
-      (step(:termination_choose_date).terminate_on == "now") ? Date.current : Date.current.end_of_year
+      (step(:termination_choose_date).terminate_on == "now") ? Date.current.yesterday : Date.current.end_of_year
     end
 
     def mitglied_termination_by_section_only?

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -46,7 +46,7 @@ module Wizards::Memberships
     end
 
     def terminate_on
-      (step(:termination_choose_date).terminate_on == "now") ? Date.current.yesterday : Date.current.end_of_year
+      (step(:termination_choose_date)&.terminate_on == "now") ? Date.current.yesterday : Date.current.end_of_year
     end
 
     def mitglied_termination_by_section_only?

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -79,16 +79,11 @@ module Wizards::Memberships
     end
 
     def step_after(step_class_or_name)
-      name = step_class_or_name.is_a?(Class) ? step_class_or_name.step_name : step_class_or_name
-      case name
+      case step_class_or_name
       when :_start
         handle_start
-      when Wizards::Steps::MembershipTerminatedInfo.step_name,
-        Wizards::Steps::LeaveZusatzsektion::AskFamilyMainPerson.step_name,
-        Wizards::Steps::TerminationNoSelfService.step_name
-        nil
-      else
-        super
+      when Wizards::Steps::TerminationChooseDate
+        Wizards::Steps::LeaveZusatzsektion::Summary.step_name
       end
     end
 

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -17,8 +17,7 @@ module Wizards::Memberships
 
     attr_reader :person, :role
 
-    # TODO: Rename to sektion_name
-    def sektion
+    def sektion_name
       role.group.parent.display_name
     end
 

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -46,7 +46,11 @@ module Wizards::Memberships
     end
 
     def terminate_on
-      (step(:termination_choose_date)&.terminate_on == "now") ? Date.current.yesterday : Date.current.end_of_year
+      if step(:termination_choose_date)&.terminate_on == "now"
+        Date.current.yesterday
+      else
+        Date.current.end_of_year
+      end
     end
 
     def mitglied_termination_by_section_only?

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -69,8 +69,6 @@ module Wizards::Memberships
 
     def leave_operation_valid?
       return true unless last_step?
-      # rubocop:disable Lint/UnreachableCode
-      return true
 
       leave_operation.valid?.tap do
         leave_operation.errors.full_messages.each do |msg|
@@ -78,7 +76,6 @@ module Wizards::Memberships
         end
         leave_operation.errors.copy!(self)
       end
-      # rubocop:enable Lint/UnreachableCode
     end
 
     def step_after(step_class_or_name)

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Wizards::Memberships
+  class LeaveZusatzsektion < Wizards::Base
+    self.steps = [
+      Wizards::Steps::MembershipTerminatedInfo,
+      Wizards::Steps::LeaveZusatzsektion::AskFamilyMainPerson,
+      Wizards::Steps::TerminationNoSelfService,
+      Wizards::Steps::TerminationChooseDate,
+      Wizards::Steps::LeaveZusatzsektion::Summary
+    ]
+
+    attr_reader :person, :sektion
+
+    def initialize(current_step: 0, person: nil, sektion: nil, backoffice: false, **params)
+      super(current_step: current_step, **params)
+      @person = person
+      @sektion = sektion
+      @backoffice = backoffice
+    end
+
+    def valid?
+      super && leave_operation_valid?
+    end
+
+    def save!
+      super
+      leave_operation.save!
+    end
+
+    def leave_operation
+      @leave_operation ||= Memberships::LeaveZusatzsektion.new(sektion, terminate_on)
+    end
+
+    def backoffice?
+      @backoffice
+    end
+
+    def terminate_on
+      (step(:termination_choose_date).terminate_on == "now") ? Date.current : Date.current.end_of_year
+    end
+
+    def mitglied_termination_by_section_only?
+      # TODO: Implement
+      false
+    end
+
+    def sac_mitarbeiter?
+      @backoffice
+    end
+
+    private
+
+    def family_membership?
+      !person.household.empty?
+    end
+
+    def family_main_person?
+      # TODO: Implement
+      false
+    end
+
+    def leave_operation_valid?
+      return true unless last_step?
+      # rubocop:disable Lint/UnreachableCode
+      return true
+
+      leave_operation.valid?.tap do
+        leave_operation.errors.full_messages.each do |msg|
+          errors.add(:base, msg)
+        end
+        leave_operation.errors.copy!(self)
+      end
+      # rubocop:enable Lint/UnreachableCode
+    end
+
+    def step_after(step_class_or_name)
+      name = step_class_or_name.is_a?(Class) ? step_class_or_name.step_name : step_class_or_name
+      case name
+      when :_start
+        handle_start
+      when Wizards::Steps::MembershipTerminatedInfo.step_name,
+        Wizards::Steps::LeaveZusatzsektion::AskFamilyMainPerson.step_name,
+        Wizards::Steps::TerminationNoSelfService.step_name
+        nil
+      else
+        super
+      end
+    end
+
+    def handle_start
+      membership_role = Group::SektionsMitglieder::Mitglied.find_by(person: person)
+      if membership_role&.terminated?
+        Wizards::Steps::MembershipTerminatedInfo.step_name
+      elsif mitglied_termination_by_section_only? && !sac_mitarbeiter?
+        Wizards::Steps::TerminationNoSelfService.step_name
+      elsif family_membership? && !family_main_person?
+        Wizards::Steps::LeaveZusatzsektion::AskFamilyMainPerson.step_name
+      elsif sac_mitarbeiter?
+        Wizards::Steps::TerminationChooseDate.step_name
+      else
+        Wizards::Steps::LeaveZusatzsektion::Summary.step_name
+      end
+    end
+  end
+end

--- a/app/models/wizards/memberships/leave_zusatzsektion.rb
+++ b/app/models/wizards/memberships/leave_zusatzsektion.rb
@@ -50,8 +50,7 @@ module Wizards::Memberships
     end
 
     def mitglied_termination_by_section_only?
-      # TODO: Implement
-      false
+      role.layer_group.mitglied_termination_by_section_only
     end
 
     def sac_mitarbeiter?

--- a/app/models/wizards/steps/leave_zusatzsektion/ask_family_main_person.rb
+++ b/app/models/wizards/steps/leave_zusatzsektion/ask_family_main_person.rb
@@ -1,0 +1,16 @@
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Wizards
+  module Steps
+    module LeaveZusatzsektion
+      class AskFamilyMainPerson < Step
+        def valid?
+          false
+        end
+      end
+    end
+  end
+end

--- a/app/models/wizards/steps/leave_zusatzsektion/ask_family_main_person.rb
+++ b/app/models/wizards/steps/leave_zusatzsektion/ask_family_main_person.rb
@@ -10,6 +10,10 @@ module Wizards
         def valid?
           false
         end
+
+        def family_main_person_name
+          wizard.person.household.main_person.full_name
+        end
       end
     end
   end

--- a/app/models/wizards/steps/leave_zusatzsektion/summary.rb
+++ b/app/models/wizards/steps/leave_zusatzsektion/summary.rb
@@ -1,0 +1,13 @@
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Wizards
+  module Steps
+    module LeaveZusatzsektion
+      class Summary < Step
+      end
+    end
+  end
+end

--- a/app/models/wizards/steps/leave_zusatzsektion/summary.rb
+++ b/app/models/wizards/steps/leave_zusatzsektion/summary.rb
@@ -9,6 +9,10 @@ module Wizards
       class Summary < Step
         attribute :termination_reason, :string
         validates :termination_reason, presence: true
+
+        def family_member_names
+          wizard.person.household.members.map { |m| m.person.full_name }.to_sentence
+        end
       end
     end
   end

--- a/app/models/wizards/steps/leave_zusatzsektion/summary.rb
+++ b/app/models/wizards/steps/leave_zusatzsektion/summary.rb
@@ -7,11 +7,15 @@ module Wizards
   module Steps
     module LeaveZusatzsektion
       class Summary < Step
-        attribute :termination_reason, :string
-        validates :termination_reason, presence: true
+        attribute :termination_reason_id, :integer
+        validates :termination_reason_id, presence: true
 
         def family_member_names
           wizard.person.household.members.map { |m| m.person.full_name }.to_sentence
+        end
+
+        def termination_reason_options
+          TerminationReason.all.map { |r| [r.text, r.id] }
         end
       end
     end

--- a/app/models/wizards/steps/leave_zusatzsektion/summary.rb
+++ b/app/models/wizards/steps/leave_zusatzsektion/summary.rb
@@ -7,6 +7,8 @@ module Wizards
   module Steps
     module LeaveZusatzsektion
       class Summary < Step
+        attribute :termination_reason, :string
+        validates :termination_reason, presence: true
       end
     end
   end

--- a/app/models/wizards/steps/membership_terminated_info.rb
+++ b/app/models/wizards/steps/membership_terminated_info.rb
@@ -12,7 +12,6 @@ class Wizards::Steps::MembershipTerminatedInfo < Wizards::Step
   end
 
   def termination_date
-    role = Group::SektionsMitglieder::Mitglied.find_by(person: wizard.person)
-    role.end_on
+    wizard.person.sac_membership.stammsektion_role.end_on
   end
 end

--- a/app/models/wizards/steps/termination_choose_date.rb
+++ b/app/models/wizards/steps/termination_choose_date.rb
@@ -6,8 +6,15 @@
 module Wizards
   module Steps
     class TerminationChooseDate < Step
-      def valid?
-        false
+      TERMINATE_ON_OPTIONS = %w[now end_of_year].freeze
+      attribute :terminate_on, :string
+
+      validates :terminate_on, presence: true, inclusion: {in: TERMINATE_ON_OPTIONS}
+
+      def terminate_on_options
+        TERMINATE_ON_OPTIONS.map do |option|
+          [option, self.class.human_attribute_name(option)]
+        end
       end
     end
   end

--- a/app/models/wizards/steps/termination_choose_date.rb
+++ b/app/models/wizards/steps/termination_choose_date.rb
@@ -13,7 +13,7 @@ module Wizards
 
       def terminate_on_options
         TERMINATE_ON_OPTIONS.map do |option|
-          [option, self.class.human_attribute_name(option)]
+          [option, self.class.human_attribute_name(option, year: Date.current.year)]
         end
       end
     end

--- a/app/models/wizards/steps/termination_choose_date.rb
+++ b/app/models/wizards/steps/termination_choose_date.rb
@@ -1,0 +1,14 @@
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Wizards
+  module Steps
+    class TerminationChooseDate < Step
+      def valid?
+        false
+      end
+    end
+  end
+end

--- a/app/models/wizards/steps/termination_no_self_service.rb
+++ b/app/models/wizards/steps/termination_no_self_service.rb
@@ -1,0 +1,14 @@
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Wizards
+  module Steps
+    class TerminationNoSelfService < Step
+      def valid?
+        false
+      end
+    end
+  end
+end

--- a/app/views/memberships/leave_zusatzsektions/_form.html.haml
+++ b/app/views/memberships/leave_zusatzsektions/_form.html.haml
@@ -4,5 +4,5 @@
 -#  https://github.com/hitobito/hitobito_sac_cas.
 - @sheet = Sheet::Memberships::LeaveZusatzsektion.new(self, nil, group)
 
-= standard_form(wizard, url: group_person_leave_zusatzsektion_path(group_id: group.id, person_id: person.id), data: { controller: 'forwarder'}) do |f|
+= standard_form(wizard, url: group_person_role_leave_zusatzsektion_path(group_id: group.id, person_id: person.id), data: { controller: 'forwarder'}) do |f|
   = render StepsComponent.new(partials: wizard.partials, step: wizard.current_step, form: f)

--- a/app/views/memberships/leave_zusatzsektions/_form.html.haml
+++ b/app/views/memberships/leave_zusatzsektions/_form.html.haml
@@ -1,0 +1,8 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+- @sheet = Sheet::Memberships::LeaveZusatzsektion.new(self, nil, group)
+
+= standard_form(wizard, url: group_person_leave_zusatzsektion_path(group_id: group.id, person_id: person.id), data: { controller: 'forwarder'}) do |f|
+  = render StepsComponent.new(partials: wizard.partials, step: wizard.current_step, form: f)

--- a/app/views/memberships/leave_zusatzsektions/show.html.haml
+++ b/app/views/memberships/leave_zusatzsektions/show.html.haml
@@ -1,0 +1,1 @@
+= render 'form'

--- a/app/views/wizards/steps/_termination_choose_date.html.haml
+++ b/app/views/wizards/steps/_termination_choose_date.html.haml
@@ -1,0 +1,6 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+= c.bottom_toolbar

--- a/app/views/wizards/steps/_termination_choose_date.html.haml
+++ b/app/views/wizards/steps/_termination_choose_date.html.haml
@@ -3,4 +3,9 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_sac_cas.
 
-= c.bottom_toolbar
+.alert.alert-info
+  = t('.info_text')
+= c.fields_for do |form|
+  = form.labeled(:terminate_on) do
+    - form.object.terminate_on_options.each do |key, label|
+      = form.inline_radio_button :terminate_on, key, label

--- a/app/views/wizards/steps/_termination_no_self_service.html.haml
+++ b/app/views/wizards/steps/_termination_no_self_service.html.haml
@@ -1,0 +1,6 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+= c.bottom_toolbar

--- a/app/views/wizards/steps/_termination_no_self_service.html.haml
+++ b/app/views/wizards/steps/_termination_no_self_service.html.haml
@@ -3,4 +3,5 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_sac_cas.
 
-= c.bottom_toolbar
+.alert.alert-info
+  = t('.info_text')

--- a/app/views/wizards/steps/leave_zusatzsektion/_ask_family_main_person.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_ask_family_main_person.html.haml
@@ -3,4 +3,5 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_sac_cas.
 
-= c.bottom_toolbar
+.alert.alert-info
+  = t('.info_text', family_main_person: c.model.family_main_person_name)

--- a/app/views/wizards/steps/leave_zusatzsektion/_ask_family_main_person.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_ask_family_main_person.html.haml
@@ -1,0 +1,6 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+= c.bottom_toolbar

--- a/app/views/wizards/steps/leave_zusatzsektion/_no_self_service.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_no_self_service.html.haml
@@ -1,0 +1,6 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+= c.bottom_toolbar

--- a/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
@@ -10,5 +10,5 @@
 .row
   %p=t('.info_text', terminate_on: c.model.wizard.terminate_on, sektion: c.model.wizard.sektion_name)
 = c.fields_for do |form|
-  = form.labeled(:termination_reason) do
-    = form.select :termination_reason, ['einfach so', 'weiss nicht'], {prompt: true}
+  = form.labeled(:termination_reason_id) do
+    = form.select :termination_reason_id, c.model.termination_reason_options, {prompt: true}

--- a/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
@@ -1,0 +1,8 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+.row
+  %p=t('.info_text', terminate_on: c.model.wizard.terminate_on, sektion: c.model.wizard.sektion)
+= c.bottom_toolbar

--- a/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
@@ -5,6 +5,6 @@
 
 .row
   %p=t('.info_text', terminate_on: c.model.wizard.terminate_on, sektion: c.model.wizard.sektion)
-= c.fields_for(next_text: t('.request_termination')) do |form|
+= c.fields_for do |form|
   = form.labeled(:termination_reason) do
     = form.select :termination_reason, ['einfach so', 'weiss nicht'], {prompt: true}

--- a/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/hitobito/hitobito_sac_cas.
 
 .row
-  %p=t('.info_text', terminate_on: c.model.wizard.terminate_on, sektion: c.model.wizard.sektion)
+  %p=t('.info_text', terminate_on: c.model.wizard.terminate_on, sektion: c.model.wizard.sektion_name)
 = c.fields_for do |form|
   = form.labeled(:termination_reason) do
     = form.select :termination_reason, ['einfach so', 'weiss nicht'], {prompt: true}

--- a/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
@@ -5,4 +5,6 @@
 
 .row
   %p=t('.info_text', terminate_on: c.model.wizard.terminate_on, sektion: c.model.wizard.sektion)
-= c.bottom_toolbar
+= c.fields_for(next_text: t('.request_termination')) do |form|
+  = form.labeled(:termination_reason) do
+    = form.select :termination_reason, ['einfach so', 'weiss nicht'], {prompt: true}

--- a/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_summary.html.haml
@@ -3,6 +3,10 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_sac_cas.
 
+
+- if c.model.wizard.family_membership?
+  .alert.alert-warning
+    = t('.family_warning', family_member_names: c.model.family_member_names)
 .row
   %p=t('.info_text', terminate_on: c.model.wizard.terminate_on, sektion: c.model.wizard.sektion_name)
 = c.fields_for do |form|

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -13,6 +13,10 @@ de:
     wizards/steps/choose_membership_title: Familienmitgliedschaft
     wizards/steps/choose_sektion_title: Sektion wählen
     wizards/steps/join_zusatzsektion/summary_title: Bestätigung
+    wizards/steps/termination_no_self_service_title: Mitgliederdienst kontaktieren
+    wizards/steps/termination_choose_date_title: Austrittsdatum
+    wizards/steps/leave_zusatzsektion/ask_family_main_person_title: Familienmitgliedschaft
+    wizards/steps/leave_zusatzsektion/summary_title: Bestätigung
 
   errors:
     messages:

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -1243,6 +1243,8 @@ de:
     Falls du deine Mitgliedschaft wieder aktivieren möchtest, besuche bitte die SAC Webseite."
       termination_choose_date:
         info_text: "Wann soll der Austritt stattfinden?"
+      termination_no_self_service:
+        info_text: "Wir bitten dich den Austritt telefonisch oder per E-Mail zu beantragen. Nimm dazu bitte Kontakt mit uns auf."
       leave_zusatzsektion:
         ask_family_main_person:
           info_text: "Der Austritt aus der Zusatzsektion kann nur für die gesamte Familienmitgliedschaft beantragt werden und muss von der Hauptperson in deiner Familienmitgliedschaft angefragt werden. Bitte wende dich an %{family_main_person}."

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -1065,6 +1065,11 @@ de:
         success: 
           one: "Deine Zusatzmitgliedschaft in <i>%{group_name}</i> wurde erstellt."
           other: "Eure %{count} Zusatzmitgliedschaften in <i>%{group_name}</i> wurden erstellt."
+    leave_zusatzsektions:
+      create:
+        success:
+          one: "Deine Zusatzmitgliedschaft in <i>%{group_name}</i> wurde gelöscht."
+          other: "Eure %{count} Zusatzmitgliedschaften in <i>%{group_name}</i> wurden gelöscht."
 
   roles:
     beitragskategorie:

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -1247,5 +1247,7 @@ de:
         ask_family_main_person:
           info_text: "Der Austritt aus der Zusatzsektion kann nur für die gesamte Familienmitgliedschaft beantragt werden und muss von der Hauptperson in deiner Familienmitgliedschaft angefragt werden. Bitte wende dich an %{family_main_person}."
         summary:
+          family_warning: "Achtung: Der Austritt aus der Zusatzsektion wird für die gesamte Familienmitgliedschaft beantragt.
+Davon betroffen sind: %{family_member_names}."
           info_text: "Bist du sicher, dass Du per %{terminate_on} aus der Sektion %{sektion} austreten möchtest?"
           next_button: "Austritt beantragen"

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -1225,3 +1225,6 @@ de:
       membership_terminated_info:
         info: "Deine Mitgliedschaft ist gekündigt per %{date}.
     Falls du deine Mitgliedschaft wieder aktivieren möchtest, besuche bitte die SAC Webseite."
+      leave_zusatzsektion:
+        summary:
+          info_text: "Bist du sicher, dass Du per %{terminate_on} aus der Sektion %{sektion} austreten möchtest?"

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -1208,6 +1208,9 @@ de:
   sheet/memberships/join_zusatzsektion:
     title: Zusatzsektion beitreten
 
+  sheet/memberships/leave_zusatzsektion:
+    title: Zusatzsektion verlassen
+
   wizards:
     steps:
       choose_sektion:

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -74,7 +74,7 @@ de:
         end_of_year: "Auf 31.12.%{year}"
 
       wizards/steps/leave_zusatzsektion/summary:
-        termination_reason: 'Austrittsgrund'
+        termination_reason_id: 'Austrittsgrund'
 
     errors:
       messages:

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -1246,4 +1246,4 @@ de:
       leave_zusatzsektion:
         summary:
           info_text: "Bist du sicher, dass Du per %{terminate_on} aus der Sektion %{sektion} austreten möchtest?"
-          request_termination: "Austritt beantragen"
+          next_button: "Austritt beantragen"

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -70,6 +70,8 @@ de:
 
       wizards/steps/termination_choose_date:
         terminate_on: 'Austrittsdatum'
+        now: Sofort
+        end_of_year: "Auf 31.12.%{year}"
 
       wizards/steps/leave_zusatzsektion/summary:
         termination_reason: 'Austrittsgrund'

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -1244,6 +1244,8 @@ de:
       termination_choose_date:
         info_text: "Wann soll der Austritt stattfinden?"
       leave_zusatzsektion:
+        ask_family_main_person:
+          info_text: "Der Austritt aus der Zusatzsektion kann nur für die gesamte Familienmitgliedschaft beantragt werden und muss von der Hauptperson in deiner Familienmitgliedschaft angefragt werden. Bitte wende dich an %{family_main_person}."
         summary:
           info_text: "Bist du sicher, dass Du per %{terminate_on} aus der Sektion %{sektion} austreten möchtest?"
           next_button: "Austritt beantragen"

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -34,7 +34,7 @@ de:
       memberships/join_base:
         join_date: Beitrittsdatum
       memberships/leave_zusatzsektion:
-        terminate_on: Beitrittsdatum
+        terminate_on: Austrittsdatum
       people/neuanmeldungen/reject:
         note: Bemerkung
       self_inscription:

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -68,6 +68,9 @@ de:
       wizards/steps/main_email:
         email: Haupt-E-Mail
 
+      wizards/steps/termination_choose_date:
+        terminate_on: 'Austrittsdatum'
+
     errors:
       messages:
         must_be_older_than_18: Person muss 18 Jahre oder älter sein.
@@ -1225,6 +1228,8 @@ de:
       membership_terminated_info:
         info: "Deine Mitgliedschaft ist gekündigt per %{date}.
     Falls du deine Mitgliedschaft wieder aktivieren möchtest, besuche bitte die SAC Webseite."
+      termination_choose_date:
+        info_text: "Wann soll der Austritt stattfinden?"
       leave_zusatzsektion:
         summary:
           info_text: "Bist du sicher, dass Du per %{terminate_on} aus der Sektion %{sektion} austreten möchtest?"

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -71,6 +71,9 @@ de:
       wizards/steps/termination_choose_date:
         terminate_on: 'Austrittsdatum'
 
+      wizards/steps/leave_zusatzsektion/summary:
+        termination_reason: 'Austrittsgrund'
+
     errors:
       messages:
         must_be_older_than_18: Person muss 18 Jahre oder älter sein.
@@ -1233,3 +1236,4 @@ de:
       leave_zusatzsektion:
         summary:
           info_text: "Bist du sicher, dass Du per %{terminate_on} aus der Sektion %{sektion} austreten möchtest?"
+          request_termination: "Austritt beantragen"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,8 +39,9 @@ Rails.application.routes.draw do
         resources :membership_invoices, only: [:create], module: :people
         resources :sac_remarks, only: %i[index edit update], module: :people
         resource :join_zusatzsektion, module: :memberships, only: [:show, :create]
-        resource :leave_zusatzsektion, module: :memberships, only: [:show, :create]
-
+        resources :roles, only: [] do
+          resource :leave_zusatzsektion, module: :memberships, only: [:show, :create]
+        end
         member do
           # Test route to check invoice positions for a person.
           # Remove once invoices are sent to abacus

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
         resources :membership_invoices, only: [:create], module: :people
         resources :sac_remarks, only: %i[index edit update], module: :people
         resource :join_zusatzsektion, module: :memberships, only: [:show, :create]
+        resource :leave_zusatzsektion, module: :memberships, only: [:show, :create]
 
         member do
           # Test route to check invoice positions for a person.

--- a/db/seeds/development/5_termination_reasons.rb
+++ b/db/seeds/development/5_termination_reasons.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+TerminationReason.seed_once(:id, id: 1, text: 'Kein Interesse mehr')
+TerminationReason.seed_once(:id, id: 2, text: 'Weggezogen')
+TerminationReason.seed_once(:id, id: 3, text: 'Verstorben')

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -81,6 +81,7 @@ module HitobitoSacCas
       Ability.store.register SacSectionMembershipConfigAbility
       Ability.store.register TerminationReasonAbility
       Ability.store.register Memberships::JoinZusatzsektionAbility
+      Ability.store.register Memberships::LeaveZusatzsektionAbility
       AbilityDsl::Base.prepend SacCas::AbilityDsl::Base
       Event::ParticipationAbility.prepend SacCas::Event::ParticipationAbility
       GroupAbility.prepend SacCas::GroupAbility

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -58,6 +58,7 @@ module HitobitoSacCas
       SelfRegistration.prepend SacCas::SelfRegistration
       SelfRegistration::MainPerson.prepend SacCas::SelfRegistration::MainPerson
       Roles::Termination.prepend SacCas::Roles::Termination
+      Roles::TerminateRoleLink.prepend SacCas::Roles::TerminateRoleLink
       Qualification.include SacCas::Qualification
       QualificationKind.include SacCas::QualificationKind
       Contactable.prepend SacCas::Contactable

--- a/spec/abilities/memberships/leave_zusatzsektion_ability_spec.rb
+++ b/spec/abilities/memberships/leave_zusatzsektion_ability_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require "spec_helper"
+
+describe Memberships::LeaveZusatzsektionAbility do
+  def build_role(type, group)
+    Fabricate(type.sti_name, group: groups(group)).tap do |r|
+      r.person.roles = [r]
+    end
+  end
+
+  let(:sektion) { groups(:bluemlisalp) }
+  let(:group) { groups(:geschaeftsstelle) }
+
+  def build_leave(person)
+    Wizards::Memberships::LeaveZusatzsektion.new(current_step: 0, person: people(person))
+  end
+
+  subject(:ability) { Ability.new(role.person) }
+
+  context "as admin" do
+    let(:role) { build_role(Group::Geschaeftsstelle::Admin, :geschaeftsstelle) }
+
+    it "may create leave for mitglied" do
+      expect(ability).to be_able_to(:create, build_leave(:mitglied))
+    end
+
+    it "may not create leave if membership is no longer active" do
+      roles(:mitglied).update(deleted_at: 1.day.ago)
+      expect(ability).not_to be_able_to(:create, build_leave(:mitglied))
+    end
+
+    it "may not create leave for admin as admin has no membership" do
+      expect(ability).not_to be_able_to(:create, build_leave(:admin))
+    end
+  end
+
+  context "as mitarbeiter" do
+    let(:role) { build_role(Group::Geschaeftsstelle::Mitarbeiter, :geschaeftsstelle) }
+
+    it "may create leave for mitglied" do
+      expect(ability).to be_able_to(:create, build_leave(:mitglied))
+    end
+
+    it "may not create leave if membership is no longer active" do
+      roles(:mitglied).update(deleted_at: 1.day.ago)
+      expect(ability).not_to be_able_to(:create, build_leave(:mitglied))
+    end
+
+    it "may not create leave for admin as admin has no membership" do
+      expect(ability).not_to be_able_to(:create, build_leave(:admin))
+    end
+  end
+
+  context "as person with active membership" do
+    let(:role) { roles(:mitglied) }
+
+    it "may create leave for herself" do
+      expect(ability).to be_able_to(:create, build_leave(:mitglied))
+    end
+
+    it "may not create leave for other person" do
+      expect(ability).not_to be_able_to(:create, build_leave(:familienmitglied))
+    end
+
+    it "may not create leave for herself if membership is no longer active" do
+      roles(:mitglied).update_columns(deleted_at: Time.zone.now)
+      expect(ability).not_to be_able_to(:create, build_leave(:mitglied))
+    end
+  end
+end

--- a/spec/components/previews/wizards_preview.rb
+++ b/spec/components/previews/wizards_preview.rb
@@ -38,6 +38,40 @@ class WizardsPreview < ViewComponent::Preview
     end
   end
 
+  def leave_zusatzsektion_wizard(current_step: 0, step: 0, next: nil,
+    person_id: Group::SektionsMitglieder::MitgliedZusatzsektion.first.person.id,
+    wizards_memberships_leave_zusatzsektion: {})
+    next_step = begin
+      Integer(binding.local_variable_get(:next))
+    rescue
+      nil
+    end
+
+    person = Person.find(person_id)
+    wizard = Wizards::Memberships::LeaveZusatzsektion.new(
+      current_step: step.to_i,
+      person: person,
+      role: person.roles.find_by!(type: "Group::SektionsMitglieder::MitgliedZusatzsektion"),
+      **wizards_memberships_leave_zusatzsektion
+    )
+
+    if wizard.valid? && step.to_i < next_step.to_i
+      wizard.move_on
+    end
+
+    render_wrapped(wizard) do |view_ctx|
+      view_ctx.content_tag(:div, class: "alert alert-info") do
+        content = [
+          view_ctx.content_tag(:p,
+            "Rendering as #{person} with sac_family:  #{person.sac_family_main_person}"),
+          view_ctx.link_to("Reset", "/rails/view_components/wizards/leave_zusatzsektion_wizard")
+
+        ]
+        safe_join(content)
+      end
+    end
+  end
+
   def choose_sektion_step(wizards_preview_wizard: {})
     wizard = build_wizard(Wizards::Steps::ChooseSektion, wizards_preview_wizard)
     def wizard.backoffice?

--- a/spec/features/memberships/leave_zusatzsektion_spec.rb
+++ b/spec/features/memberships/leave_zusatzsektion_spec.rb
@@ -67,6 +67,7 @@ describe "leave zusatzsektion", js: true do
       expect(page).to have_title "Zusatzsektion verlassen"
       select "einfach so"
       expect do
+        expect(page).to have_content "Der Austritt aus der Zusatzsektion wird für die gesamte Familienmitgliedschaft beantragt"
         click_button "Austritt beantragen"
         expect(page).to have_content "Eure 3 Zusatzmitgliedschaften in #{role.group.parent.name} wurden gelöscht."
       end

--- a/spec/features/memberships/leave_zusatzsektion_spec.rb
+++ b/spec/features/memberships/leave_zusatzsektion_spec.rb
@@ -54,6 +54,17 @@ describe "leave zusatzsektion", js: true do
         .and change { role.reload.terminated }.to(true)
       expect(role.delete_on).not_to be_nil
     end
+
+    context "when sektion has mitglied_termination_by_section_only=true" do
+      before do
+        role.layer_group.update!(mitglied_termination_by_section_only: true)
+      end
+
+      it "shows an info text" do
+        visit group_person_role_leave_zusatzsektion_path(group_id: group.id, person_id: person.id, role_id: role.id)
+        expect(page).to have_content("Wir bitten dich den Austritt telefonisch oder per E-Mail zu beantragen.")
+      end
+    end
   end
 
   context "as family main person" do

--- a/spec/features/memberships/leave_zusatzsektion_spec.rb
+++ b/spec/features/memberships/leave_zusatzsektion_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe "leave zusatzsektion", js: true do
+  before do
+    sign_in(person)
+  end
+
+  context "as normal user" do
+    let(:group) { groups(:bluemlisalp_mitglieder) }
+    let(:person) { people(:mitglied) }
+    let(:role) { person.roles.second }
+
+    it "can execute wizard" do
+      visit history_group_person_path(group_id: group.id, id: person.id)
+      within("#role_#{role.id}") do
+        click_link "Austritt"
+      end
+      expect(page).to have_title "Zusatzsektion verlassen"
+      choose "Sofort"
+      click_button "Weiter"
+      select "einfach so"
+      expect do
+        click_button "Austritt beantragen"
+        expect(page).to have_content "Deine Zusatzmitgliedschaft in #{role.group.parent.name} wurde gelöscht."
+      end
+        .to change { person.roles.count }.by(-1)
+        .and change { role.reload.deleted_at }.from(nil)
+    end
+  end
+end

--- a/spec/features/memberships/leave_zusatzsektion_spec.rb
+++ b/spec/features/memberships/leave_zusatzsektion_spec.rb
@@ -12,6 +12,7 @@ describe "leave zusatzsektion", js: true do
   let(:role) { person.roles.second }
   let(:operator) { person }
   let(:group) { groups(:bluemlisalp_mitglieder) }
+  let(:termination_reason) { termination_reasons(:moved) }
 
   before do
     sign_in(operator)
@@ -28,13 +29,16 @@ describe "leave zusatzsektion", js: true do
       expect(page).to have_title "Zusatzsektion verlassen"
       choose "Sofort"
       click_button "Weiter"
-      select "einfach so"
+      select termination_reason.text
       expect do
         click_button "Austritt beantragen"
         expect(page).to have_content "Deine Zusatzmitgliedschaft in #{role.group.parent.name} wurde gelöscht."
+        role.reload
       end
         .to change { person.roles.count }.by(-1)
-        .and change { role.reload.deleted_at }.from(nil)
+        .and change { role.deleted_at }.from(nil)
+      # TODO: https://github.com/hitobito/hitobito_sac_cas/issues/718
+      # .and change { role.termination_reason }.from(nil).to(termination_reson)
     end
   end
 
@@ -45,13 +49,16 @@ describe "leave zusatzsektion", js: true do
         click_link "Austritt"
       end
       expect(page).to have_title "Zusatzsektion verlassen"
-      select "einfach so"
+      select termination_reason.text
       expect do
         click_button "Austritt beantragen"
         expect(page).to have_content "Deine Zusatzmitgliedschaft in #{role.group.parent.name} wurde gelöscht."
+        role.reload
       end
         .to not_change { person.roles.count }
-        .and change { role.reload.terminated }.to(true)
+        .and change { role.terminated }.to(true)
+      # TODO: https://github.com/hitobito/hitobito_sac_cas/issues/718
+      # .and change { role.termination_reason }.from(nil).to(termination_reson)
       expect(role.delete_on).not_to be_nil
     end
 
@@ -76,7 +83,7 @@ describe "leave zusatzsektion", js: true do
         click_link "Austritt"
       end
       expect(page).to have_title "Zusatzsektion verlassen"
-      select "einfach so"
+      select termination_reason.text
       expect do
         expect(page).to have_content "Der Austritt aus der Zusatzsektion wird für die gesamte Familienmitgliedschaft beantragt"
         click_button "Austritt beantragen"
@@ -84,6 +91,8 @@ describe "leave zusatzsektion", js: true do
       end
         .to not_change { person.roles.count }
         .and change { role.reload.terminated }.to(true)
+      # TODO: https://github.com/hitobito/hitobito_sac_cas/issues/718
+      #  .and change { role.termination_reason_text }.from(nil).to("einfach so")
     end
   end
 

--- a/spec/fixtures/termination_reason/translations.yml
+++ b/spec/fixtures/termination_reason/translations.yml
@@ -5,8 +5,8 @@
 
 ---
 moved:
-  termination_reason_id: <%= ActiveRecord::FixtureSet.identify(:reason) %>
+  termination_reason_id: <%= ActiveRecord::FixtureSet.identify(:moved) %>
   locale: de
-  text: Austrittsgrund
+  text: Umgezogen
   created_at: <%= Time.zone.now %>
   updated_at: <%= Time.zone.now %>

--- a/spec/models/wizards/memberships/leave_zusatzsektion_spec.rb
+++ b/spec/models/wizards/memberships/leave_zusatzsektion_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Wizards::Memberships::LeaveZusatzsektion do
+  let(:matterhorn) { groups(:matterhorn) }
+  let(:bluemlisalp) { groups(:bluemlisalp) }
+  let(:backoffice) { false }
+  let(:params) { {} }
+  let(:role) { person.roles.find_by!(type: "Group::SektionsMitglieder::MitgliedZusatzsektion") }
+  let(:primary_role) { person.roles.find_by!(type: "Group::SektionsMitglieder::Mitglied") }
+  let(:person) { people(:mitglied) }
+  let(:current_step) { 0 }
+  let(:wizard) do
+    described_class.new(current_step:, backoffice:, person:, role:, **params)
+  end
+
+  context "with terminated primary role" do
+    it "only has MembershipTerminatedInfo step" do
+      primary_role.update_column(:terminated, true)
+      expect(wizard.step_at(0)).to be_kind_of(Wizards::Steps::MembershipTerminatedInfo)
+      expect(wizard.step_at(1)).to be_nil
+    end
+  end
+
+  def expect_backoffice_steps
+    expect(wizard.step_at(0)).to be_kind_of(Wizards::Steps::TerminationChooseDate)
+    expect(wizard.step_at(1)).to be_kind_of(Wizards::Steps::LeaveZusatzsektion::Summary)
+    expect(wizard.step_at(2)).to be_nil
+  end
+
+  context "If termination is by section only" do
+    before do
+      allow(wizard.role.layer_group).to receive(:mitglied_termination_by_section_only).and_return(true)
+    end
+
+    it "only has TerminationNoSelfService step" do
+      expect(wizard.step_at(0)).to be_kind_of(Wizards::Steps::TerminationNoSelfService)
+      expect(wizard.step_at(1)).to be_nil
+    end
+
+    context "when operator is backoffice" do
+      let(:backoffice) { true }
+
+      it "includes the backoffice steps" do
+        expect_backoffice_steps
+      end
+    end
+  end
+
+  context "for main person inside a household" do
+    let(:person) { people(:familienmitglied) }
+
+    it "only has the Summary step" do
+      expect(wizard.step_at(0)).to be_kind_of(Wizards::Steps::LeaveZusatzsektion::Summary)
+      expect(wizard.step_at(1)).to be_nil
+      expect(wizard).not_to be_valid
+    end
+  end
+
+  context "when operator is backoffice" do
+    let(:backoffice) { true }
+
+    it "includes the backoffice steps" do
+      expect_backoffice_steps
+    end
+  end
+
+  context "for person inside a household" do
+    let(:person) { people(:familienmitglied2) }
+
+    it "only has the AskFamilyMainPerson step" do
+      expect(wizard.step_at(0)).to be_kind_of(Wizards::Steps::LeaveZusatzsektion::AskFamilyMainPerson)
+      expect(wizard.step_at(1)).to be_nil
+    end
+
+    it "has family_membership" do
+      expect(wizard.family_membership?).to be true
+    end
+  end
+end

--- a/spec/models/wizards/steps/leave_zusatzsektion/ask_family_main_person_spec.rb
+++ b/spec/models/wizards/steps/leave_zusatzsektion/ask_family_main_person_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+#
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Wizards::Steps::LeaveZusatzsektion::AskFamilyMainPerson do
+  let(:params) { {} }
+  let(:wizard) { nil } # we don't need a wizard for the model specs
+  let(:subject) { described_class.new(wizard, **params) }
+
+  it "is always invalid" do
+    is_expected.not_to be_valid
+  end
+
+  describe "#family_main_person_name" do
+    let(:person) { people(:familienmitglied2) }
+    let(:wizard) { Wizards::Base.new(current_step: 0) }
+
+    before do
+      allow(wizard).to receive(:person).and_return(person)
+    end
+
+    it "returns the family main person's name" do
+      expect(subject.family_main_person_name).to eq(people(:familienmitglied).full_name)
+    end
+  end
+end

--- a/spec/models/wizards/steps/leave_zusatzsektion/summary_spec.rb
+++ b/spec/models/wizards/steps/leave_zusatzsektion/summary_spec.rb
@@ -13,15 +13,15 @@ describe Wizards::Steps::LeaveZusatzsektion::Summary do
   let(:wizard) { nil } # we don't need a wizard for the model specs
   let(:subject) { described_class.new(wizard, **params) }
 
-  context "without termination_reason" do
+  context "without termination_reason_id" do
     it "is invalid" do
       is_expected.not_to be_valid
-      expect(subject.errors[:termination_reason]).to include("muss ausgefüllt werden")
+      expect(subject.errors[:termination_reason_id]).to include("muss ausgefüllt werden")
     end
   end
 
   context "with termination_reason" do
-    let(:params) { {termination_reason: "Test Termination"} }
+    let(:params) { {termination_reason_id: termination_reasons(:moved).id} }
 
     it { is_expected.to be_valid }
   end

--- a/spec/models/wizards/steps/leave_zusatzsektion/summary_spec.rb
+++ b/spec/models/wizards/steps/leave_zusatzsektion/summary_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Wizards::Steps::LeaveZusatzsektion::Summary do
+  let(:params) { {} }
+  let(:wizard) { nil } # we don't need a wizard for the model specs
+  let(:subject) { described_class.new(wizard, **params) }
+
+  context "without termination_reason" do
+    it "is invalid" do
+      is_expected.not_to be_valid
+      expect(subject.errors[:termination_reason]).to include("muss ausgefüllt werden")
+    end
+  end
+
+  context "with termination_reason" do
+    let(:params) { {termination_reason: "Test Termination"} }
+
+    it { is_expected.to be_valid }
+  end
+
+  describe "#family_member_names" do
+    let(:person) { people(:familienmitglied) }
+    let(:wizard) { Wizards::Base.new(current_step: 0) }
+
+    before do
+      allow(wizard).to receive(:person).and_return(person)
+    end
+
+    it "returns the family member names" do
+      expect(subject.family_member_names).to eq("Tenzing Norgay, Frieda Norgay und Nima Norgay")
+    end
+  end
+end

--- a/spec/models/wizards/steps/termination_choose_date_spec.rb
+++ b/spec/models/wizards/steps/termination_choose_date_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Wizards::Steps::TerminationChooseDate do
+  let(:params) { {} }
+  let(:wizard) { nil } # we don't need a wizard for the model specs
+  let(:subject) { described_class.new(wizard, **params) }
+
+  describe "validations" do
+    context "without terminate_on" do
+      it do
+        is_expected.not_to be_valid
+        expect(subject.errors[:terminate_on].count).to eq 2
+      end
+    end
+
+    context "with invalid terminate_on" do
+      let(:params) { {terminate_on: "invalid"} }
+
+      it do
+        is_expected.not_to be_valid
+        expect(subject.errors[:terminate_on].count).to eq 1
+      end
+    end
+
+    context "with valid terminate_on" do
+      let(:params) { {terminate_on: "now"} }
+
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/spec/models/wizards/steps/termination_no_self_service_spec.rb
+++ b/spec/models/wizards/steps/termination_no_self_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+#
+#  Copyright (c) 2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Wizards::Steps::TerminationNoSelfService do
+  let(:params) { {} }
+  let(:wizard) { nil } # we don't need a wizard for the model specs
+  let(:subject) { described_class.new(wizard, **params) }
+
+  it "is always invalid" do
+    is_expected.not_to be_valid
+  end
+end


### PR DESCRIPTION
Refs: #627 

TODO
 * [ ] Request specs
 * [ ] Model specs


TODO für follow up PR:
 * [ ] Mailer MembershipsMailer#zusatzsektion_leave_confirmation implementieren
 * [ ] Use `TerminationReason` reference. -> Seeds are missing. (https://github.com/hitobito/hitobito_sac_cas/pull/714)
 * [ ] Handle "Falls auf der Sektion/Ortsgruppe das #mitglied_termination_by_section_only true ist
Warnung anzeigen" for `ChooseDate` step.