### PR TITLE
SacCas Konstanten Namen verbessern

### DIFF
--- a/app/abilities/sac_cas/role_ability.rb
+++ b/app/abilities/sac_cas/role_ability.rb
@@ -35,10 +35,6 @@ module SacCas::RoleAbility
     SacCas::MITGLIED_ROLES.include?(role.class)
   end
 
-  def mitglied_hauptsektion_role?(role = subject)
-    SacCas::MITGLIED_HAUPTSEKTION_ROLES.include?(role.class)
-  end
-
   def mitglied_zusatzsektion_role?(role = subject)
     SacCas::MITGLIED_ZUSATZSEKTION_ROLES.include?(role.class)
   end

--- a/app/domain/groups/primary.rb
+++ b/app/domain/groups/primary.rb
@@ -7,7 +7,7 @@
 
 module Groups
   class Primary
-    ROLE_TYPES = SacCas::HAUPTSEKTION_ROLES.map(&:sti_name).freeze
+    ROLE_TYPES = SacCas::STAMMSEKTION_ROLES.map(&:sti_name).freeze
 
     GROUP_TYPES = ROLE_TYPES.collect(&:deconstantize).freeze
 

--- a/app/domain/groups/primary.rb
+++ b/app/domain/groups/primary.rb
@@ -7,7 +7,7 @@
 
 module Groups
   class Primary
-    ROLE_TYPES = SacCas::MITGLIED_HAUPTSEKTION_ROLES.map(&:sti_name).freeze
+    ROLE_TYPES = SacCas::HAUPTSEKTION_ROLES.map(&:sti_name).freeze
 
     GROUP_TYPES = ROLE_TYPES.collect(&:deconstantize).freeze
 

--- a/app/domain/people/sac_family.rb
+++ b/app/domain/people/sac_family.rb
@@ -167,11 +167,11 @@ class People::SacFamily
   #end
 
   def stammsektion_role_types
-    SacCas::MITGLIED_HAUPTSEKTION_ROLES.map(&:sti_name)
+    SacCas::HAUPTSEKTION_ROLES.map(&:sti_name)
   end
 
   def zusatzsektion_role_types
-    SacCas::MITGLIED_ZUSATZSEKTION_ROLES.map(&:sti_name)
+    SacCas::ZUSATZSEKTION_ROLES.map(&:sti_name)
   end
 
   def all_member_and_neuanmeldung_role_types

--- a/app/domain/people/sac_family.rb
+++ b/app/domain/people/sac_family.rb
@@ -167,7 +167,7 @@ class People::SacFamily
   #end
 
   def stammsektion_role_types
-    SacCas::HAUPTSEKTION_ROLES.map(&:sti_name)
+    SacCas::STAMMSEKTION_ROLES.map(&:sti_name)
   end
 
   def zusatzsektion_role_types

--- a/app/domain/people/sac_membership.rb
+++ b/app/domain/people/sac_membership.rb
@@ -32,7 +32,7 @@ class People::SacMembership
   end
 
   def roles
-    @person.roles.select { |r| SacCas::MITGLIED_HAUPTSEKTION_ROLES.include?(r.class) }
+    @person.roles.select { |r| SacCas::MITGLIED_STAMMSEKTION_ROLES.include?(r.class) }
   end
 
   # There should be only one active `Mitglied` role at a time anyway
@@ -46,7 +46,7 @@ class People::SacMembership
 
   private
 
-  def stammsektion_mitglied_sti_names = SacCas::MITGLIED_HAUPTSEKTION_ROLES.map(&:sti_name)
+  def stammsektion_mitglied_sti_names = SacCas::MITGLIED_STAMMSEKTION_ROLES.map(&:sti_name)
   def mitglied_and_neuanmeldung_sti_names = SacCas::MITGLIED_AND_NEUANMELDUNG_ROLES.map(&:sti_name)
 
   def any_future_role?

--- a/app/domain/people/sac_membership.rb
+++ b/app/domain/people/sac_membership.rb
@@ -7,14 +7,8 @@
 
 class People::SacMembership
 
-  MEMBERSHIP_ROLES = [
-    Group::SektionsMitglieder::Mitglied
-  ].freeze
-
   def initialize(person)
     @person = person
-    @roles = MEMBERSHIP_ROLES.map(&:sti_name)
-    @active_or_approvable_roles = SacCas::MITGLIED_HAUPTSEKTION_ROLES.map(&:sti_name)
   end
 
   def active?
@@ -24,13 +18,13 @@ class People::SacMembership
   # checks for any active membership roles
   def active_in?(sac_section)
     @person.roles.exists?(group_id: sac_section.children,
-                          type: @roles)
+                          type: stammsektion_mitglied_sti_names)
   end
 
   # checkes for active and also approvabable (neuanmeldung) roles
   def active_or_approvable_in?(sac_section)
     @person.roles.exists?(group_id: sac_section.children,
-                          type: @active_or_approvable_roles)
+                          type: mitglied_and_neuanmeldung_sti_names)
   end
 
   def anytime?
@@ -38,7 +32,7 @@ class People::SacMembership
   end
 
   def roles
-    @person.roles.select { |r| MEMBERSHIP_ROLES.include?(r.class) }
+    @person.roles.select { |r| SacCas::MITGLIED_HAUPTSEKTION_ROLES.include?(r.class) }
   end
 
   # There should be only one active `Mitglied` role at a time anyway
@@ -52,11 +46,14 @@ class People::SacMembership
 
   private
 
+  def stammsektion_mitglied_sti_names = SacCas::MITGLIED_HAUPTSEKTION_ROLES.map(&:sti_name)
+  def mitglied_and_neuanmeldung_sti_names = SacCas::MITGLIED_AND_NEUANMELDUNG_ROLES.map(&:sti_name)
+
   def any_future_role?
-    @person.roles.future.where(convert_to: @roles).exists?
+    @person.roles.future.where(convert_to: stammsektion_mitglied_sti_names).exists?
   end
 
   def any_past_role?
-    @person.roles.deleted.where(type: @roles).exists?
+    @person.roles.deleted.where(type: stammsektion_mitglied_sti_names).exists?
   end
 end

--- a/app/domain/sac_cas.rb
+++ b/app/domain/sac_cas.rb
@@ -9,8 +9,8 @@ module SacCas
 
   ### Membership roles
 
-  MITGLIED_HAUPTSEKTION_ROLES = [::Group::SektionsMitglieder::Mitglied].freeze
-  NEUANMELDUNG_HAUPTSEKTION_ROLES = [
+  MITGLIED_STAMMSEKTION_ROLES = [::Group::SektionsMitglieder::Mitglied].freeze
+  NEUANMELDUNG_STAMMSEKTION_ROLES = [
     ::Group::SektionsNeuanmeldungenNv::Neuanmeldung,
     ::Group::SektionsNeuanmeldungenSektion::Neuanmeldung
   ].freeze
@@ -22,12 +22,12 @@ module SacCas
   ].freeze
 
   MITGLIED_ROLES = [
-    MITGLIED_HAUPTSEKTION_ROLES,
+    MITGLIED_STAMMSEKTION_ROLES,
     MITGLIED_ZUSATZSEKTION_ROLES
   ].flatten.freeze
 
   NEUANMELDUNG_ROLES = [
-    NEUANMELDUNG_HAUPTSEKTION_ROLES,
+    NEUANMELDUNG_STAMMSEKTION_ROLES,
     NEUANMELDUNG_ZUSATZSEKTION_ROLES
   ].flatten.freeze
 
@@ -36,9 +36,9 @@ module SacCas
     NEUANMELDUNG_ROLES
   ].flatten.freeze
 
-  HAUPTSEKTION_ROLES = [
-    MITGLIED_HAUPTSEKTION_ROLES,
-    NEUANMELDUNG_HAUPTSEKTION_ROLES
+  STAMMSEKTION_ROLES = [
+    MITGLIED_STAMMSEKTION_ROLES,
+    NEUANMELDUNG_STAMMSEKTION_ROLES
   ].flatten.freeze
 
   ZUSATZSEKTION_ROLES = [

--- a/app/domain/sac_cas.rb
+++ b/app/domain/sac_cas.rb
@@ -7,31 +7,50 @@
 
 module SacCas
 
-  SAC_MITARBEITER_ROLES = [
-    ::Group::Geschaeftsstelle::Mitarbeiter,
-    ::Group::Geschaeftsstelle::Admin
-  ].freeze
+  ### Membership roles
 
-  MITGLIED_HAUPTSEKTION_ROLES = [
-    ::Group::SektionsMitglieder::Mitglied,
-    ::Group::SektionsNeuanmeldungenNv::Neuanmeldung,
-    ::Group::SektionsNeuanmeldungenSektion::Neuanmeldung
-  ].freeze
-
-  MITGLIED_ZUSATZSEKTION_ROLES = [
-    ::Group::SektionsMitglieder::MitgliedZusatzsektion,
-    ::Group::SektionsNeuanmeldungenNv::NeuanmeldungZusatzsektion,
-    ::Group::SektionsNeuanmeldungenSektion::NeuanmeldungZusatzsektion
-  ].freeze
-
+  MITGLIED_HAUPTSEKTION_ROLES = [::Group::SektionsMitglieder::Mitglied].freeze
   NEUANMELDUNG_HAUPTSEKTION_ROLES = [
     ::Group::SektionsNeuanmeldungenNv::Neuanmeldung,
     ::Group::SektionsNeuanmeldungenSektion::Neuanmeldung
   ].freeze
 
+  MITGLIED_ZUSATZSEKTION_ROLES = [::Group::SektionsMitglieder::MitgliedZusatzsektion].freeze
   NEUANMELDUNG_ZUSATZSEKTION_ROLES = [
     ::Group::SektionsNeuanmeldungenNv::NeuanmeldungZusatzsektion,
     ::Group::SektionsNeuanmeldungenSektion::NeuanmeldungZusatzsektion
+  ].freeze
+
+  MITGLIED_ROLES = [
+    MITGLIED_HAUPTSEKTION_ROLES,
+    MITGLIED_ZUSATZSEKTION_ROLES
+  ].flatten.freeze
+
+  NEUANMELDUNG_ROLES = [
+    NEUANMELDUNG_HAUPTSEKTION_ROLES,
+    NEUANMELDUNG_ZUSATZSEKTION_ROLES
+  ].flatten.freeze
+
+  MITGLIED_AND_NEUANMELDUNG_ROLES = [
+    MITGLIED_ROLES,
+    NEUANMELDUNG_ROLES
+  ].flatten.freeze
+
+  HAUPTSEKTION_ROLES = [
+    MITGLIED_HAUPTSEKTION_ROLES,
+    NEUANMELDUNG_HAUPTSEKTION_ROLES
+  ].flatten.freeze
+
+  ZUSATZSEKTION_ROLES = [
+    MITGLIED_ZUSATZSEKTION_ROLES,
+    NEUANMELDUNG_ZUSATZSEKTION_ROLES
+  ].flatten.freeze
+
+  ### Various roles
+
+  SAC_MITARBEITER_ROLES = [
+    ::Group::Geschaeftsstelle::Mitarbeiter,
+    ::Group::Geschaeftsstelle::Admin
   ].freeze
 
   TOUR_GUIDE_ROLES = [
@@ -39,8 +58,7 @@ module SacCas
     ::Group::SektionsTourenkommission::TourenleiterOhneQualifikation
   ].freeze
 
-  MITGLIED_ROLES = (MITGLIED_HAUPTSEKTION_ROLES + MITGLIED_ZUSATZSEKTION_ROLES).freeze
-  NEUANMELDUNG_ROLES = (NEUANMELDUNG_HAUPTSEKTION_ROLES + NEUANMELDUNG_ZUSATZSEKTION_ROLES).freeze
+  ###
 
   NEWSLETTER_MAILING_LIST_INTERNAL_KEY = 'sac_newsletter'
 

--- a/app/domain/table_displays/resolver.rb
+++ b/app/domain/table_displays/resolver.rb
@@ -67,7 +67,7 @@ module TableDisplays
     def antrag_fuer
       if group_roles.any? { |r| SacCas::NEUANMELDUNG_ZUSATZSEKTION_ROLES.include?(r.class) }
         I18n.t('groups.sektion_secondary')
-      elsif group_roles.any? { |r| SacCas::NEUANMELDUNG_HAUPTSEKTION_ROLES.include?(r.class) }
+      elsif group_roles.any? { |r| SacCas::NEUANMELDUNG_STAMMSEKTION_ROLES.include?(r.class) }
         I18n.t('groups.sektion_primary')
       end
     end
@@ -111,7 +111,7 @@ module TableDisplays
     end
 
     def membership_roles
-      Role.where(type: SacCas::MITGLIED_HAUPTSEKTION_ROLES.collect(&:sti_name),
+      Role.where(type: SacCas::MITGLIED_STAMMSEKTION_ROLES.collect(&:sti_name),
                  person_id: @person.id)
     end
 

--- a/app/models/group/sektions_mitglieder.rb
+++ b/app/models/group/sektions_mitglieder.rb
@@ -11,7 +11,7 @@ class Group::SektionsMitglieder < ::Group
 
   ### ROLES
   class Mitglied < ::Role
-    include SacCas::Role::MitgliedHauptsektion
+    include SacCas::Role::MitgliedStammsektion
 
     self.terminatable = true
 

--- a/app/models/group/sektions_neuanmeldungen_nv.rb
+++ b/app/models/group/sektions_neuanmeldungen_nv.rb
@@ -11,7 +11,7 @@ class Group::SektionsNeuanmeldungenNv < ::Group
 
   ### ROLES
   class Neuanmeldung < ::Role
-    include SacCas::Role::MitgliedHauptsektion
+    include SacCas::Role::MitgliedStammsektion
     include SacCas::Role::HardDestroy
   end
 

--- a/app/models/group/sektions_neuanmeldungen_sektion.rb
+++ b/app/models/group/sektions_neuanmeldungen_sektion.rb
@@ -11,7 +11,7 @@ class Group::SektionsNeuanmeldungenSektion < ::Group
 
   ### ROLES
   class Neuanmeldung < ::Role
-    include SacCas::Role::MitgliedHauptsektion
+    include SacCas::Role::MitgliedStammsektion
     include SacCas::Role::HardDestroy
   end
 

--- a/app/models/sac_cas/event/participation.rb
+++ b/app/models/sac_cas/event/participation.rb
@@ -24,7 +24,7 @@ module SacCas::Event::Participation
 
   def subsidizable?
     event.course? && person.roles.any? do |role|
-      role.class.include?(SacCas::Role::MitgliedHauptsektion)
+      role.class.include?(SacCas::Role::MitgliedStammsektion)
     end
   end
 

--- a/app/models/sac_cas/role.rb
+++ b/app/models/sac_cas/role.rb
@@ -57,7 +57,7 @@ module SacCas::Role
   protected
 
   def preferred_primary?
-    SacCas::MITGLIED_HAUPTSEKTION_ROLES.include?(type.safe_constantize)
+    SacCas::HAUPTSEKTION_ROLES.include?(type.safe_constantize)
   end
 
   private

--- a/app/models/sac_cas/role.rb
+++ b/app/models/sac_cas/role.rb
@@ -57,7 +57,7 @@ module SacCas::Role
   protected
 
   def preferred_primary?
-    SacCas::HAUPTSEKTION_ROLES.include?(type.safe_constantize)
+    SacCas::STAMMSEKTION_ROLES.include?(type.safe_constantize)
   end
 
   private

--- a/app/models/sac_cas/role/mitglied_family_validations.rb
+++ b/app/models/sac_cas/role/mitglied_family_validations.rb
@@ -28,7 +28,7 @@ module SacCas::Role::MitgliedFamilyValidations
     people = person.
              household_people.
              joins(:roles).
-             merge(Role.where(type: SacCas::HAUPTSEKTION_ROLES,
+             merge(Role.where(type: SacCas::STAMMSEKTION_ROLES,
                               beitragskategorie: :family)).to_a
 
     people << person

--- a/app/models/sac_cas/role/mitglied_family_validations.rb
+++ b/app/models/sac_cas/role/mitglied_family_validations.rb
@@ -28,7 +28,7 @@ module SacCas::Role::MitgliedFamilyValidations
     people = person.
              household_people.
              joins(:roles).
-             merge(Role.where(type: SacCas::MITGLIED_HAUPTSEKTION_ROLES,
+             merge(Role.where(type: SacCas::HAUPTSEKTION_ROLES,
                               beitragskategorie: :family)).to_a
 
     people << person

--- a/app/models/sac_cas/role/mitglied_no_overlap_validation.rb
+++ b/app/models/sac_cas/role/mitglied_no_overlap_validation.rb
@@ -27,7 +27,7 @@ module SacCas::Role::MitgliedNoOverlapValidation
   end
 
   def assert_no_overlapping_primary_memberships
-    overlapping_roles(active_period, SacCas::MITGLIED_HAUPTSEKTION_ROLES).tap do |conflicting_roles|
+    overlapping_roles(active_period, SacCas::HAUPTSEKTION_ROLES).tap do |conflicting_roles|
       conflicting_roles.each { |conflicting_role| add_overlap_error(conflicting_role) }
     end
   end

--- a/app/models/sac_cas/role/mitglied_no_overlap_validation.rb
+++ b/app/models/sac_cas/role/mitglied_no_overlap_validation.rb
@@ -18,7 +18,7 @@ module SacCas::Role::MitgliedNoOverlapValidation
     return unless start_on.present? && end_on.present? # we can't validate without a period
 
     case self
-    when SacCas::Role::MitgliedHauptsektion
+    when SacCas::Role::MitgliedStammsektion
       assert_no_overlapping_primary_memberships
       assert_no_overlapping_memberships_per_layer
     when SacCas::Role::MitgliedZusatzsektion
@@ -27,7 +27,7 @@ module SacCas::Role::MitgliedNoOverlapValidation
   end
 
   def assert_no_overlapping_primary_memberships
-    overlapping_roles(active_period, SacCas::HAUPTSEKTION_ROLES).tap do |conflicting_roles|
+    overlapping_roles(active_period, SacCas::STAMMSEKTION_ROLES).tap do |conflicting_roles|
       conflicting_roles.each { |conflicting_role| add_overlap_error(conflicting_role) }
     end
   end

--- a/app/models/sac_cas/role/mitglied_stammsektion.rb
+++ b/app/models/sac_cas/role/mitglied_stammsektion.rb
@@ -5,7 +5,7 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas.
 
-module SacCas::Role::MitgliedHauptsektion
+module SacCas::Role::MitgliedStammsektion
   extend ActiveSupport::Concern
 
   include SacCas::Role::MitgliedCommon

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -895,7 +895,7 @@ de:
   groups:
     actions_show_sac_cas:
       export_mitglieder: CSV Mitglieder
-    sektion_primary: Hauptsektion
+    sektion_primary: Stammsektion
     sektion_secondary: Zusatzsektion
 
     self_registration:

--- a/spec/abilities/sac_cas/role_ability_spec.rb
+++ b/spec/abilities/sac_cas/role_ability_spec.rb
@@ -49,7 +49,7 @@ describe RoleAbility do
         expect(ability).not_to be_able_to(:terminate, role_zusatzsektion)
       end
 
-      it 'is permitted when having Hauptsektion with Sektion#mitglied_termination_by_section_only' do
+      it 'is permitted when having Stammsektion with Sektion#mitglied_termination_by_section_only' do
         set_termination_by_section_only(role_stammsektion, true)
         set_termination_by_section_only(role_zusatzsektion, false)
         expect(ability).to be_able_to(:terminate, role_zusatzsektion)

--- a/spec/domain/table_displays/resolver_spec.rb
+++ b/spec/domain/table_displays/resolver_spec.rb
@@ -71,7 +71,7 @@ describe TableDisplays::Resolver, type: :helper do
   end
 
   it_behaves_like 'resolver', attr: :antrag_fuer, label: 'Antrag für' do
-    { Hauptsektion: [
+    { Stammsektion: [
         Group::SektionsNeuanmeldungenNv::Neuanmeldung,
         Group::SektionsNeuanmeldungenSektion::Neuanmeldung
       ],

--- a/spec/features/roles/terminations_spec.rb
+++ b/spec/features/roles/terminations_spec.rb
@@ -18,7 +18,7 @@ describe :roles_terminations, js: true do
   end
 
   it 'lists all affected roles' do
-    # when terminating the hauptsektion role, the affected roles include
+    # when terminating the stammsektion role, the affected roles include
     # all zusatzektion roles as well
     visit_dialog(roles(:mitglied))
 
@@ -37,7 +37,7 @@ describe :roles_terminations, js: true do
   end
 
   it 'mentions the affected people' do
-    # when terminating the hauptsektion role of a family member, the affected people
+    # when terminating the stammsektion role of a family member, the affected people
     # include all family members
     visit_dialog(roles(:familienmitglied))
 

--- a/spec/models/future_role_spec.rb
+++ b/spec/models/future_role_spec.rb
@@ -33,15 +33,15 @@ describe FutureRole do
     let(:group) { TargetGroup.new }
 
     it 'returns true if convert_to is a SacCas::MITGLIED_ROLES' do
-      SacCas::MITGLIED_ROLES.each do |role_type|
+      SacCas::MITGLIED_AND_NEUANMELDUNG_ROLES.each do |role_type|
         role = FutureRole.new(convert_to: role_type.sti_name, group: group)
         expect(role.validate_target_type?).to eq(true),
                                               "was unexpectedly false for #{role_type.sti_name}"
       end
     end
 
-    it 'returns false if convert_to is not a SacCas::MITGLIED_ROLES' do
-      (Role.all_types - SacCas::MITGLIED_ROLES).each do |role_type|
+    it 'returns false if convert_to is not a SacCas::MITGLIED_AND_NEUANMELDUNG_ROLES' do
+      (Role.all_types - SacCas::MITGLIED_AND_NEUANMELDUNG_ROLES).each do |role_type|
         role = FutureRole.new(convert_to: role_type.sti_name, group: group)
         expect(role.validate_target_type?).to eq(false),
                                               "was unexpectedly true for #{role_type.sti_name}"

--- a/spec/models/group/mitglied_no_overlap_validation_spec.rb
+++ b/spec/models/group/mitglied_no_overlap_validation_spec.rb
@@ -211,7 +211,7 @@ describe :mitglied_no_overlap_validation do
       end
     end
 
-    # Hauptsektion Mitgliedschaften/Neuanmeldungen
+    # Stammsektion Mitgliedschaften/Neuanmeldungen
     it_behaves_like 'deny concurrent role in same layer',
                     existing: [Group::SektionsMitglieder::Mitglied, :bluemlisalp_mitglieder],
                     new: [Group::SektionsMitglieder::Mitglied, :bluemlisalp_mitglieder]
@@ -262,7 +262,7 @@ describe :mitglied_no_overlap_validation do
                     existing: [Group::SektionsMitglieder::MitgliedZusatzsektion, :bluemlisalp_mitglieder],
                     new: [Group::SektionsNeuanmeldungenSektion::NeuanmeldungZusatzsektion, :bluemlisalp_ortsgruppe_ausserberg_neuanmeldungen_nv]
 
-    # Hauptsektion + Zusatzsektion
+    # Stammsektion + Zusatzsektion
 
     it_behaves_like 'deny concurrent role in same layer',
                     existing: [Group::SektionsMitglieder::Mitglied, :bluemlisalp_mitglieder],

--- a/spec/models/household_spec.rb
+++ b/spec/models/household_spec.rb
@@ -22,6 +22,8 @@ describe Household do
 
   subject!(:household) { Household.new(person) }
 
+  def sequence = Sequence.by_name(SacCas::Person::Household::HOUSEHOLD_KEY_SEQUENCE)
+
   before do
     travel_to(Date.new(2024, 5, 31))
   end
@@ -37,9 +39,13 @@ describe Household do
   end
 
   it 'uses sequence for household key' do
-    add_and_save(adult)
-    expect(Sequence.find_by(current_value: '500001').name).to eq 'person.household_key'
-    expect(adult.reload.household_key).to eq '500001'
+    expect do
+      household = adult.household
+      household.add(child)
+      household.save!
+    end.to change { sequence.current_value }.by(1)
+
+    expect(adult.reload.household_key).to eq sequence.current_value.to_s
   end
 
   describe 'validations' do


### PR DESCRIPTION
Die Konstanten hatten ungenaue, irreführende Namen und wurden entsprechend auch schon falsch verwendet.

Dieser commit passt die Konstanten Namen an für bessere Verständlichkeit.