### PR TITLE
PEOPLE: Bemerkungsfelder in API

### DIFF
--- a/app/resources/sac_cas/person_resource.rb
+++ b/app/resources/sac_cas/person_resource.rb
@@ -21,19 +21,15 @@ module SacCas::PersonResource
       attribute :membership_number, :integer do
         @object.membership_number if @object.sac_membership_anytime?
       end
-      extra_attribute :sac_remark_national_office, :string, readable: :can_read_national_office_remark?
+      attribute :sac_remark_national_office, :string do
+         @object.sac_remark_national_office if can?(:manage_national_office_remark, @object)
+      end
 
       (1..5).each do |num|
-        extra_attribute :"sac_remark_section_#{num}", :string, readable: :can_read_section_remarks?
+        attribute :"sac_remark_section_#{num}", :string do
+          @object.send(:"sac_remark_section_#{num}") if can?(:manage_section_remarks, @object)
+        end
       end
-    end
-
-    def can_read_national_office_remark?(person)
-      can?(:manage_national_office_remark, person)
-    end
-
-    def can_read_section_remarks?(person)
-      can?(:manage_section_remarks, person)
     end
   end
 end

--- a/app/resources/sac_cas/person_resource.rb
+++ b/app/resources/sac_cas/person_resource.rb
@@ -22,7 +22,7 @@ module SacCas::PersonResource
         @object.membership_number if @object.sac_membership_anytime?
       end
       attribute :sac_remark_national_office, :string do
-         @object.sac_remark_national_office if can?(:manage_national_office_remark, @object)
+        @object.sac_remark_national_office if can?(:manage_national_office_remark, @object)
       end
 
       (1..5).each do |num|

--- a/app/resources/sac_cas/person_resource.rb
+++ b/app/resources/sac_cas/person_resource.rb
@@ -22,7 +22,7 @@ module SacCas::PersonResource
         @object.membership_number if @object.sac_membership_anytime?
       end
       extra_attribute :sac_remark_national_office, :string, readable: :can_read_national_office_remark?
-  
+
       (1..5).each do |num|
         extra_attribute :"sac_remark_section_#{num}", :string, readable: :can_read_section_remarks?
       end
@@ -31,7 +31,7 @@ module SacCas::PersonResource
     def can_read_national_office_remark?(person)
       can?(:manage_national_office_remark, person)
     end
-    
+
     def can_read_section_remarks?(person)
       can?(:manage_section_remarks, person)
     end

--- a/app/resources/sac_cas/person_resource.rb
+++ b/app/resources/sac_cas/person_resource.rb
@@ -9,16 +9,31 @@ module SacCas::PersonResource
   extend ActiveSupport::Concern
 
   included do
-    attribute :family_id, :string, writable: false, sortable: false, filterable: false
-    attribute :membership_number, :integer, writable: false, sortable: false, fiterable: false do
-      @object.membership_number if @object.sac_membership_anytime?
-    end
-
     extra_attribute :membership_years, :integer, sortable: true, filterable: true do
       @object.membership_years if @object.sac_membership_anytime?
     end
     on_extra_attribute :membership_years do |scope|
       scope.with_membership_years
+    end
+
+    with_options writable: false, sortable: false, filterable: false do
+      attribute :family_id, :string
+      attribute :membership_number, :integer do
+        @object.membership_number if @object.sac_membership_anytime?
+      end
+      extra_attribute :sac_remark_national_office, :string, readable: :can_read_national_office_remark?
+  
+      (1..5).each do |num|
+        extra_attribute :"sac_remark_section_#{num}", :string, readable: :can_read_section_remarks?
+      end
+    end
+
+    def can_read_national_office_remark?(person)
+      can?(:manage_national_office_remark, person)
+    end
+    
+    def can_read_section_remarks?(person)
+      can?(:manage_section_remarks, person)
     end
   end
 end

--- a/spec/api/people/show_spec.rb
+++ b/spec/api/people/show_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require "spec_helper"
+
+RSpec.describe "people#show", type: :request do
+  let(:token) { service_tokens(:permitted_root_layer_token).token }
+  let(:person) { people(:admin) }
+
+  subject(:make_request) { jsonapi_get "/api/people/#{person.id}" }
+
+  before do
+    person.update!(sac_remark_national_office: "Remark", sac_remark_section_1: "Remark")
+    sign_in(person)
+  end
+
+  context "as employee" do
+    it "can read national office remark but not section remarks" do
+      make_request
+      expect(d.sac_remark_national_office).to eq("Remark")
+      expect(d.sac_remark_section_1).to be_blank
+    end
+  end
+
+  context "as section functionary" do
+    before do
+      person.roles.destroy_all
+      person.roles.create!(
+        group: groups(:matterhorn_funktionaere),
+        type: Group::SektionsFunktionaere::Administration.sti_name
+      )
+    end
+
+    it "can read section remarks but not national office remark" do
+      make_request
+      expect(d.sac_remark_national_office).to be_blank
+      expect(d.sac_remark_section_1).to eq("Remark")
+    end
+  end
+end

--- a/spec/api/people/show_spec.rb
+++ b/spec/api/people/show_spec.rb
@@ -8,37 +8,36 @@
 require "spec_helper"
 
 RSpec.describe "people#show", type: :request do
-  let(:token) { service_tokens(:permitted_root_layer_token).token }
-  let(:person) { people(:admin) }
+  it_behaves_like "jsonapi authorized requests" do
+    let(:token) { service_tokens(:permitted_root_layer_token).token }
+    let(:person) { people(:admin) }
 
-  subject(:make_request) { jsonapi_get "/api/people/#{person.id}" }
+    subject(:make_request) { jsonapi_get "/api/people/#{person.id}" }
 
-  before do
-    person.update!(sac_remark_national_office: "Remark", sac_remark_section_1: "Remark")
-    sign_in(person)
-  end
+    before { person.update!(sac_remark_national_office: "Remark", sac_remark_section_1: "Remark") }
 
-  context "as employee" do
-    it "can read national office remark but not section remarks" do
-      make_request
-      expect(d.sac_remark_national_office).to eq("Remark")
-      expect(d.sac_remark_section_1).to be_blank
-    end
-  end
-
-  context "as section functionary" do
-    before do
-      person.roles.destroy_all
-      person.roles.create!(
-        group: groups(:matterhorn_funktionaere),
-        type: Group::SektionsFunktionaere::Administration.sti_name
-      )
+    context "as employee" do
+      it "can read national office remark but not section remarks" do
+        sign_in(person)
+        make_request
+        expect(d.sac_remark_national_office).to eq("Remark")
+        expect(d.sac_remark_section_1).to be_blank
+      end
     end
 
-    it "can read section remarks but not national office remark" do
-      make_request
-      expect(d.sac_remark_national_office).to be_blank
-      expect(d.sac_remark_section_1).to eq("Remark")
+    context "as section functionary" do
+      it "can read section remarks but not national office remark" do
+        person.roles.destroy_all
+        person.roles.create!(
+          group: groups(:matterhorn_funktionaere),
+          type: Group::SektionsFunktionaere::Administration.sti_name
+        )
+        sign_in(person)
+
+        make_request
+        expect(d.sac_remark_national_office).to be_blank
+        expect(d.sac_remark_section_1).to eq("Remark")
+      end
     end
   end
 end

--- a/spec/resources/person/reads_spec.rb
+++ b/spec/resources/person/reads_spec.rb
@@ -67,5 +67,18 @@ RSpec.describe PersonResource, type: :resource do
         end
       end
     end
+
+    context "sac_remark_national_office" do
+      it "is not included" do
+        render
+        expect(attributes.keys).not_to include :sac_remark_national_office
+      end
+
+      it "can be requested" do
+        params[:extra_fields] = {people: "sac_remark_national_office"}
+        render
+        expect(attributes.keys).to include :sac_remark_national_office
+      end
+    end
   end
 end

--- a/spec/resources/person/reads_spec.rb
+++ b/spec/resources/person/reads_spec.rb
@@ -68,16 +68,12 @@ RSpec.describe PersonResource, type: :resource do
       end
     end
 
-    context "sac_remark_national_office" do
-      it "is not included" do
+    context "sac_remarks" do
+      it "is included" do
         render
-        expect(attributes.keys).not_to include :sac_remark_national_office
-      end
-
-      it "can be requested" do
-        params[:extra_fields] = {people: "sac_remark_national_office"}
-        render
-        expect(attributes.keys).to include :sac_remark_national_office
+        Person::SAC_REMARKS.each do |remark|
+          expect(attributes.keys).to include remark.to_sym
+        end
       end
     end
   end

--- a/spec/support/graphiti/schema.json
+++ b/spec/support/graphiti/schema.json
@@ -2200,6 +2200,36 @@
           "type": "integer",
           "readable": true,
           "description": null
+        },
+        "sac_remark_national_office": {
+          "type": "string",
+          "readable": "guarded",
+          "description": null
+        },
+        "sac_remark_section_1": {
+          "type": "string",
+          "readable": "guarded",
+          "description": null
+        },
+        "sac_remark_section_2": {
+          "type": "string",
+          "readable": "guarded",
+          "description": null
+        },
+        "sac_remark_section_3": {
+          "type": "string",
+          "readable": "guarded",
+          "description": null
+        },
+        "sac_remark_section_4": {
+          "type": "string",
+          "readable": "guarded",
+          "description": null
+        },
+        "sac_remark_section_5": {
+          "type": "string",
+          "readable": "guarded",
+          "description": null
         }
       },
       "sorts": {
@@ -2442,17 +2472,6 @@
         },
         "updated_at": {
           "type": "datetime",
-          "operators": [
-            "eq",
-            "not_eq",
-            "gt",
-            "gte",
-            "lt",
-            "lte"
-          ]
-        },
-        "membership_number": {
-          "type": "integer",
           "operators": [
             "eq",
             "not_eq",

--- a/spec/support/graphiti/schema.json
+++ b/spec/support/graphiti/schema.json
@@ -2193,42 +2193,48 @@
           "readable": true,
           "writable": false,
           "description": null
+        },
+        "sac_remark_national_office": {
+          "type": "string",
+          "readable": true,
+          "writable": false,
+          "description": null
+        },
+        "sac_remark_section_1": {
+          "type": "string",
+          "readable": true,
+          "writable": false,
+          "description": null
+        },
+        "sac_remark_section_2": {
+          "type": "string",
+          "readable": true,
+          "writable": false,
+          "description": null
+        },
+        "sac_remark_section_3": {
+          "type": "string",
+          "readable": true,
+          "writable": false,
+          "description": null
+        },
+        "sac_remark_section_4": {
+          "type": "string",
+          "readable": true,
+          "writable": false,
+          "description": null
+        },
+        "sac_remark_section_5": {
+          "type": "string",
+          "readable": true,
+          "writable": false,
+          "description": null
         }
       },
       "extra_attributes": {
         "membership_years": {
           "type": "integer",
           "readable": true,
-          "description": null
-        },
-        "sac_remark_national_office": {
-          "type": "string",
-          "readable": "guarded",
-          "description": null
-        },
-        "sac_remark_section_1": {
-          "type": "string",
-          "readable": "guarded",
-          "description": null
-        },
-        "sac_remark_section_2": {
-          "type": "string",
-          "readable": "guarded",
-          "description": null
-        },
-        "sac_remark_section_3": {
-          "type": "string",
-          "readable": "guarded",
-          "description": null
-        },
-        "sac_remark_section_4": {
-          "type": "string",
-          "readable": "guarded",
-          "description": null
-        },
-        "sac_remark_section_5": {
-          "type": "string",
-          "readable": "guarded",
           "description": null
         }
       },


### PR DESCRIPTION
Fixes #518

- Testbar auf z.B. http://localhost:3000/api/people/600780
- Wenn man keine Berechtigungen hat, ein `remark` feld zu sehen, wird dies in der API trotzdem angezeigt, aber immer mit `null` als Wert