### PR TITLE
Fix Memberships::FamilyMutation#leave!, hide people manager aside

### DIFF
--- a/app/models/memberships/family_mutation.rb
+++ b/app/models/memberships/family_mutation.rb
@@ -39,7 +39,10 @@ module Memberships
 
       beitragskategorie = SacCas::Beitragskategorie::Calculator
         .new(person).calculate(for_sac_family: false)
-      replace_role!(sac_membership.stammsektion_role, beitragskategorie:)
+
+      if sac_membership.stammsektion_role
+        replace_role!(sac_membership.stammsektion_role, beitragskategorie:)
+      end
       sac_membership.future_stammsektion_roles.each { replace_role!(_1, beitragskategorie:) }
       sac_membership.zusatzsektion_roles.family.each { replace_role!(_1, beitragskategorie:) }
     end

--- a/app/views/people/_people_managers_aside.html.haml
+++ b/app/views/people/_people_managers_aside.html.haml
@@ -1,0 +1,10 @@
+- # frozen_string_literal: true
+-
+- #  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+- #  hitobito and licensed under the Affero General Public License version 3
+- #  or later. See the COPYING file at the top-level directory or at
+- #  https://github.com/hitobito/hitobito.
+
+- # This feature is not used in the SAC wagon as people managers are managed implicitely
+- # with the household feature.
+- # So we override the view partial from youth wagon with a blank one.

--- a/spec/features/people/managers_spec.rb
+++ b/spec/features/people/managers_spec.rb
@@ -3,94 +3,11 @@ require "spec_helper"
 describe "people management", :js do
   let(:current_user) { people(:admin) }
   let(:heading) { "Kinder / Verwalter*innen" }
-  let(:adult) { create_person(birthday: 25.years.ago) }
-  let(:child) { create_person(birthday: 15.years.ago) }
+  let(:person) { people(:familienmitglied) }
 
-  def create_person(**opts)
-    Fabricate(:person, primary_group: groups(:externe_kontakte), **opts).tap do |person|
-      create_contact_role(person) # add a role to make the person findable
-    end
-  end
-
-  def create_contact_role(person)
-    Group::ExterneKontakte::Kontakt.create!(person: person, group: groups(:externe_kontakte))
-  end
-
-  def within_turbo_frame
-    within("turbo-frame#people_managers") do
-      yield
-    end
-  end
-
-  def find_person(name)
-    # The dropdown does not reliably open in capybara. Filling in any string first seems to help.
-    fill_in "Person suchen...", with: " "
-    fill_in "Person suchen...", with: name
-    find('ul[role="listbox"] li[role="option"]', text: name).click
-  end
-
-  before { sign_in(current_user) }
-
-  it "can assign and remove managed child to adult" do
-    visit group_person_path(group_id: adult.primary_group_id, id: adult)
-
-    within_turbo_frame do
-      expect(page).to have_css("h2", text: heading)
-      click_link("Kind zuweisen")
-      find_person child.full_name
-      click_on "Speichern"
-      expect(page).to have_css("h2", text: "Kinder")
-      expect(page).to have_link child.full_name
-      expect(page).to have_link "Kind zuweisen"
-    end
-
-    refresh
-    # check that the managed is also added to the household
-    within(".contactable") do
-      expect(page).to have_link(child.full_name)
-    end
-
-    within_turbo_frame do
-      accept_alert("wirklich löschen") do
-        click_link "Löschen"
-      end
-      expect(page).to have_css("h2", text: heading)
-      expect(page).not_to have_link "Bottom Member"
-    end
-
-    refresh
-    # check that the managed is also removed from the household
-    within(".contactable") do
-      expect(page).to have_no_link(child.full_name)
-    end
-  end
-
-  it "cannot assign managed adult to adult" do
-    create_person(birthday: 25.years.ago)
-    visit group_person_path(group_id: adult.primary_group_id, id: adult)
-
-    within_turbo_frame do
-      expect(page).to have_css("h2", text: heading)
-      expect(page).to have_link("Kind zuweisen")
-      expect(page).to have_link(count: 1)
-    end
-  end
-
-  it "cannot assign manager to child" do
-    visit group_person_path(group_id: child.primary_group_id, id: child)
-
-    within_turbo_frame do
-      expect(page).to have_css("h2", text: heading)
-      expect(page).to have_no_link
-    end
-  end
-
-  it "cannot assign managed to child" do
-    visit group_person_path(group_id: child.primary_group_id, id: child)
-
-    within_turbo_frame do
-      expect(page).to have_css("h2", text: heading)
-      expect(page).to have_no_link
-    end
+  it "has no managers aside" do
+    visit group_person_path(group_id: person.primary_group_id, id: person.id)
+    expect(page).to have_no_selector("turbo-frame#people_managers")
+    expect(page).to have_no_content(heading)
   end
 end

--- a/spec/models/memberships/family_mutations_spec.rb
+++ b/spec/models/memberships/family_mutations_spec.rb
@@ -233,5 +233,11 @@ describe Memberships::FamilyMutation do
       expect(new_future_role.convert_on).to eq original_future_stammsektion_role.convert_on
       expect(new_future_role.convert_to).to eq original_future_stammsektion_role.convert_to
     end
+
+    it "does not crash if the person has no stammsektion" do
+      Role.where(person_id: roles(:familienmitglied).id).delete_all
+      mutation = described_class.new(people(:familienmitglied))
+      expect { mutation.leave! }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
* Prevent crash in Memberships::FamilyMutation#leave! when person has no
  stammsektion membership
* hide people manager aside on person show view

Fixes #712