### PR TITLE
Feature/627 Show warning in choose date step in austritt zusatzsektion wizard

### DIFF
--- a/app/views/wizards/steps/_termination_choose_date.html.haml
+++ b/app/views/wizards/steps/_termination_choose_date.html.haml
@@ -3,6 +3,9 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito_sac_cas.
 
+- if c.model.wizard.mitglied_termination_by_section_only?
+  .alert.alert-warning
+    = t('.warning_termination_by_section_only')
 .alert.alert-info
   = t('.info_text')
 = c.fields_for do |form|

--- a/app/views/wizards/steps/leave_zusatzsektion/_no_self_service.html.haml
+++ b/app/views/wizards/steps/leave_zusatzsektion/_no_self_service.html.haml
@@ -1,6 +1,0 @@
--#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
--#  hitobito_sac_cas and licensed under the Affero General Public License version 3
--#  or later. See the COPYING file at the top-level directory or at
--#  https://github.com/hitobito/hitobito_sac_cas.
-
-= c.bottom_toolbar

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -1250,6 +1250,8 @@ de:
     Falls du deine Mitgliedschaft wieder aktivieren möchtest, besuche bitte die SAC Webseite."
       termination_choose_date:
         info_text: "Wann soll der Austritt stattfinden?"
+        warning_termination_by_section_only: "Achtung: der Austritt findet bei einer Sektion statt, bei der die Austrittsfunktion für das Mitglied deaktiviert ist.
+Allenfalls musst du den Austritt vorgängig mit der Sektion abklären."
       termination_no_self_service:
         info_text: "Wir bitten dich den Austritt telefonisch oder per E-Mail zu beantragen. Nimm dazu bitte Kontakt mit uns auf."
       leave_zusatzsektion:

--- a/spec/requests/memberships/leave_zusatzsektions_controller_spec.rb
+++ b/spec/requests/memberships/leave_zusatzsektions_controller_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Memberships::LeaveZusatzsektionsController do
+  before { sign_in(operator) }
+
+  let(:operator) { person }
+  let(:bluemlisalp) { groups(:bluemlisalp) }
+  let(:matterhorn) { groups(:matterhorn) }
+  let(:role) { person.roles.find_by!(type: "Group::SektionsMitglieder::MitgliedZusatzsektion") }
+  let(:primary_role) { person.roles.find_by!(type: "Group::SektionsMitglieder::Mitglied") }
+
+  def build_params(step:, **attrs)
+    {step:, wizards_memberships_leave_zusatzsektion: attrs}
+  end
+
+  describe "#GET" do
+    let(:request) do
+      get group_person_role_leave_zusatzsektion_path(group_id: bluemlisalp.id, person_id: person.id, role_id: role.id)
+    end
+    let(:person) { people(:mitglied) }
+
+    def expect_summary_step
+      expect(response).to be_successful
+      expect(response.body).to include "Zusatzsektion verlassen"
+      expect(response.body).to include "Austritt beantragen"
+    end
+
+    def expect_date_select_step
+      expect(response).to be_successful
+      expect(response.body).to include "Zusatzsektion verlassen"
+      expect(response.body).to include "Austrittsdatum"
+    end
+
+    context "as normal user" do
+      it "renders the form" do
+        request
+        expect_summary_step
+      end
+    end
+
+    context "with a terminated membership" do
+      before do
+        primary_role.write_attribute(:terminated, true)
+        primary_role.save!
+      end
+
+      def expect_terminated_page
+        expect(response).to be_successful
+        expect(response.body).to include "Deine Mitgliedschaft ist gekündigt per"
+        expect(response.body).not_to include "Weiter"
+      end
+
+      it "renders a notice" do
+        request
+        expect_terminated_page
+      end
+
+      context "as an admin" do
+        let(:operator) { people(:admin) }
+
+        it "renders a notice" do
+          request
+          expect_terminated_page
+        end
+      end
+    end
+
+    context "when sektion has mitglied_termination_by_section_only=true" do
+      before do
+        role.layer_group.update!(mitglied_termination_by_section_only: true)
+      end
+
+      it "shows an info text" do
+        request
+        expect(response).to be_successful
+        expect(response.body).to include("Wir bitten dich den Austritt telefonisch oder per E-Mail zu beantragen.")
+      end
+
+      context "as and admin" do
+        let(:operator) { people(:admin) }
+
+        it "shows the date select step with a warning" do
+          request
+          expect_date_select_step
+          expect(response.body).to include("Achtung: der Austritt findet bei einer Sektion statt, bei der die Austrittsfunktion für das Mitglied deaktiviert ist.")
+        end
+      end
+    end
+
+    context "with a family main person" do
+      let(:person) { people(:familienmitglied) }
+
+      it "shows info about affecting the whole family" do
+        request
+        expect_summary_step
+        expect(response.body).to include "Der Austritt aus der Zusatzsektion wird für die gesamte Familienmitgliedschaft beantragt."
+      end
+    end
+
+    context "with a family regular person" do
+      let(:person) { people(:familienmitglied2) }
+
+      it "shows info about the main family person" do
+        request
+        expect(response.body).to include "Bitte wende dich an #{people(:familienmitglied)}"
+      end
+    end
+
+    context "as a different user" do
+      let(:operator) { people(:familienmitglied) }
+
+      it "returns not authorized" do
+        expect { request }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context "as an admin" do
+      let(:operator) { people(:admin) }
+
+      it "shows me the select date step" do
+        request
+        expect_date_select_step
+      end
+    end
+  end
+
+  describe "#POST" do
+    let(:termination_reason_id) { termination_reasons(:moved).id }
+    let(:request) do
+      post group_person_role_leave_zusatzsektion_path(group_id: bluemlisalp.id, person_id: person.id, role_id: role.id),
+        params:
+    end
+    let(:person) { people(:mitglied) }
+    let(:params) { build_params(step: 0, summary: {termination_reason_id:}) }
+
+    context "as normal user" do
+      it "marks single role as destroyed and redirects" do
+        expect do
+          request
+          role.reload
+        end
+          .to not_change(Role, :count)
+          .and change { role.terminated }.to(true)
+          .and change { role.termination_reason_id }.from(nil).to(termination_reason_id)
+        expect(response).to redirect_to person_path(person, format: :html)
+        expect(flash[:notice]).to eq "Deine Zusatzmitgliedschaft in <i>SAC " \
+                                     "Matterhorn</i> wurde gelöscht."
+      end
+    end
+
+    context "as a different user" do
+      let(:operator) { people(:familienmitglied) }
+
+      it "returns not authorized" do
+        expect { request }.to raise_error(CanCan::AccessDenied)
+      end
+    end
+
+    context "as an admin" do
+      let(:operator) { people(:admin) }
+      let(:params) { build_params(step: 1, termination_choose_date: {terminate_on: "now"}, summary: {termination_reason_id:}) }
+
+      it "can choose immediate termination, destroy single role and redirects" do
+        expect do
+          request
+          role.reload
+        end
+          .to change(Role, :count).by(-1)
+          .and change { role.termination_reason_id }.from(nil).to(termination_reason_id)
+        expect(response).to redirect_to person_path(person, format: :html)
+        expect(flash[:notice]).to eq "Deine Zusatzmitgliedschaft in <i>SAC " \
+                                     "Matterhorn</i> wurde gelöscht."
+      end
+    end
+
+    context "as family" do
+      let(:person) { people(:familienmitglied) }
+
+      it "creates multiple roles and redirects" do
+        expect do
+          request
+          role.reload
+        end
+          .to not_change(Role, :count)
+          .and change { role.terminated }.to(true)
+          .and change { role.termination_reason_id }.from(nil).to(termination_reason_id)
+        expect(response).to redirect_to person_path(person, format: :html)
+        expect(flash[:notice]).to eq "Eure 3 Zusatzmitgliedschaften in <i>SAC " \
+                                     "Matterhorn</i> wurden gelöscht."
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref: #627 

Testing:

 * Impersonate as an admin: http://localhost:3000/de/groups/8/people/600780.html (Carlo Beltrame)
 * Go to a persons history which is a Mitglied (Zusatzsektion) http://localhost:3000/de/groups/36/people/600047/history (Nick Harter)
 * Set `mitglied_termination_by_section_only` to `true` for the affected layer: `Role.find(47).layer_group.tap { |l| l.update!(mitglied_termination_by_section_only: true) }`
 
 
![image](https://github.com/user-attachments/assets/83c9e9f7-386f-4687-bf62-56857cfc0158)
