### PR TITLE
Feature/605 switch stammsektion wizard

### DIFF
--- a/app/abilities/memberships/constraints.rb
+++ b/app/abilities/memberships/constraints.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Memberships
+  module Constraints
+    def for_self_if_active_member_or_backoffice
+      active_member? && (for_self? || backoffice?)
+    end
+
+    def backoffice?
+      user_context.user.backoffice?
+    end
+
+    def for_self?
+      subject.person == user_context.user
+    end
+
+    def active_member?
+      People::SacMembership.new(subject.person).active?
+    end
+  end
+end

--- a/app/abilities/memberships/leave_zusatzsektion_ability.rb
+++ b/app/abilities/memberships/leave_zusatzsektion_ability.rb
@@ -7,24 +7,10 @@
 
 module Memberships
   class LeaveZusatzsektionAbility < AbilityDsl::Base
+    include Memberships::Constraints
+
     on(Wizards::Memberships::LeaveZusatzsektion) do
       permission(:any).may(:create).for_self_if_active_member_or_backoffice
-    end
-
-    def for_self_if_active_member_or_backoffice
-      active_member? && (for_self? || backoffice?)
-    end
-
-    def backoffice?
-      user_context.user.backoffice?
-    end
-
-    def for_self?
-      subject.person == user_context.user
-    end
-
-    def active_member?
-      People::SacMembership.new(subject.person).active?
     end
   end
 end

--- a/app/abilities/memberships/switch_stammsektion_ability.rb
+++ b/app/abilities/memberships/switch_stammsektion_ability.rb
@@ -6,10 +6,10 @@
 #  https://github.com/hitobito/hitobito_sac_cas.
 
 module Memberships
-  class JoinZusatzsektionAbility < AbilityDsl::Base
+  class SwitchStammsektionAbility < AbilityDsl::Base
     include Memberships::Constraints
 
-    on(Wizards::Memberships::JoinZusatzsektion) do
+    on(Wizards::Memberships::SwitchStammsektion) do
       permission(:any).may(:create).for_self_if_active_member_or_backoffice
     end
   end

--- a/app/abilities/memberships/terminate_sac_membership_ability.rb
+++ b/app/abilities/memberships/terminate_sac_membership_ability.rb
@@ -7,24 +7,10 @@
 
 module Memberships
   class TerminateSacMembershipAbility < AbilityDsl::Base
+    include Memberships::Constraints
+
     on(Wizards::Memberships::TerminateSacMembershipWizard) do
       permission(:any).may(:create).for_self_if_active_member_or_backoffice
-    end
-
-    def for_self_if_active_member_or_backoffice
-      active_member? && (for_self? || backoffice?)
-    end
-
-    def backoffice?
-      user_context.user.backoffice?
-    end
-
-    def for_self?
-      subject.person == user_context.user
-    end
-
-    def active_member?
-      People::SacMembership.new(subject.person).active?
     end
   end
 end

--- a/app/components/sac_cas/steps_component/content_component.rb
+++ b/app/components/sac_cas/steps_component/content_component.rb
@@ -16,6 +16,10 @@ module SacCas::StepsComponent::ContentComponent
     end + @form.fields_for(partial_name, model, &) + bottom_toolbar
   end
 
+  def form_error_messages
+    @form.error_messages
+  end
+
   def model
     @form.object.step_at(index)
   end
@@ -29,12 +33,20 @@ module SacCas::StepsComponent::ContentComponent
   def bottom_toolbar
     content_tag(:div, class: "btn-toolbar allign-with-form") do
       buttons = [next_button]
-      buttons << back_link if index.positive?
+      buttons << if index.positive?
+        back_link
+      else
+        cancel_link
+      end
       safe_join(buttons)
     end
   end
 
   private
+
+  def cancel_link
+    link_to(t("global.button.cancel"), person_path(@form.object.person), class: "link cancel mt-2 pt-1")
+  end
 
   # Adjust to comply with existing api
   def past?

--- a/app/controllers/memberships/switch_stammsektions_controller.rb
+++ b/app/controllers/memberships/switch_stammsektions_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Memberships
+  class SwitchStammsektionsController < Wizards::BaseController
+    before_action :wizard, :person, :group, :authorize
+
+    helper_method :group, :person
+    alias_method :entry, :wizard
+
+    private
+
+    def authorize
+      authorize!(:create, wizard)
+    end
+
+    def wizard
+      @wizard ||= model_class.new(
+        person: person,
+        current_step: params[:step].to_i,
+        backoffice: current_user.backoffice?,
+        **model_params.to_unsafe_h
+      )
+    end
+
+    def model_class
+      Wizards::Memberships::SwitchStammsektion
+    end
+
+    def success_message
+      roles_count = wizard.switch_operation.affected_people.count
+      t(".success", count: roles_count, group_name: wizard.choose_sektion.group.to_s, switch_date: wizard.choose_date.switch_on_text)
+    end
+
+    # NOTE: format: :html is required otherwise it is redirect as turbo_stream
+    def redirect_target
+      person_path(person, format: :html)
+    end
+
+    def person
+      @person ||= Person.find(params[:person_id])
+    end
+
+    def group
+      @group ||= Group.find(params[:group_id])
+    end
+  end
+end

--- a/app/helpers/sheet/memberships/switch_stammsektion.rb
+++ b/app/helpers/sheet/memberships/switch_stammsektion.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Sheet::Memberships
+  class SwitchStammsektion < Sheet::Base
+    self.parent_sheet = Sheet::Person
+
+    def initialize(*args)
+      super
+      @title = I18n.t(".title", scope: self.class.to_s.underscore) # rubocop:disable Rails/HelperInstanceVariable
+    end
+  end
+end

--- a/app/mailers/memberships/switch_stammsektion_mailer.rb
+++ b/app/mailers/memberships/switch_stammsektion_mailer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Memberships
+  class SwitchStammsektionMailer < ApplicationMailer
+    CONFIRMATION = "memberships_switch_stammsektion_confirmation"
+
+    def confirmation(person, sektion, switch_on_text)
+      values = [
+        %W[person-name #{person}],
+        %W[group-name #{sektion}],
+        %W[switch-date #{switch_on_text}]
+      ].to_h
+      custom_headers = {cc: Group::Geschaeftsstelle.first.email}
+      custom_content_mail([person], CONFIRMATION, values, custom_headers)
+    end
+  end
+end

--- a/app/models/memberships/switch_stammsektion.rb
+++ b/app/models/memberships/switch_stammsektion.rb
@@ -14,7 +14,20 @@ module Memberships
 
     validate :assert_join_date
 
+    def save
+      super.tap do |success|
+        update_primary_groups
+      end
+    end
+
     private
+
+    def update_primary_groups
+      affected_people.each do |person|
+        person.reload # Unsure why this reload is necessary
+        person.update!(primary_group: Groups::Primary.new(person).identify)
+      end
+    end
 
     def prepare_roles(person)
       old_role = existing_membership(person)

--- a/app/models/wizards/memberships/switch_stammsektion.rb
+++ b/app/models/wizards/memberships/switch_stammsektion.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Wizards::Memberships
+  class SwitchStammsektion < Wizards::Base
+    self.steps = [
+      Wizards::Steps::MembershipTerminatedInfo,
+      Wizards::Steps::AskFamilyMainPerson,
+      Wizards::Steps::SwitchStammsektion::ChooseSektion,
+      Wizards::Steps::SwitchStammsektion::ChooseDate,
+      Wizards::Steps::SwitchStammsektion::Summary
+    ]
+
+    attr_reader :person
+
+    def initialize(current_step: 0, person: nil, backoffice: false, **params)
+      super(current_step: current_step, **params)
+      @person = person
+      @backoffice = backoffice
+    end
+
+    def valid?
+      super && switch_operation_valid?
+    end
+
+    def save!
+      super
+
+      switch_operation.save!.tap do
+        send_confirmation_mail
+      end
+    end
+
+    def switch_operation
+      @switch_operation ||=
+        Memberships::SwitchStammsektion.new(
+          choose_sektion.group,
+          person,
+          choose_date.switch_date
+        )
+    end
+
+    def backoffice?
+      @backoffice
+    end
+
+    private
+
+    def send_confirmation_mail
+      Memberships::SwitchStammsektionMailer.confirmation(
+        person,
+        choose_sektion.group,
+        choose_date.switch_on_text
+      ).deliver_later
+    end
+
+    def switch_operation_valid?
+      return true unless last_step?
+
+      switch_operation.valid?.tap do
+        switch_operation.errors.full_messages.each do |msg|
+          errors.add(:base, msg)
+        end
+      end
+    end
+
+    def step_after(step_class_or_name)
+      case step_class_or_name
+      when :_start
+        handle_start
+      when Wizards::Steps::MembershipTerminatedInfo, Wizards::Steps::AskFamilyMainPerson
+        nil
+      else
+        super
+      end
+    end
+
+    def handle_start
+      membership_role = Group::SektionsMitglieder::Mitglied.find_by(person: person)
+      if membership_role&.terminated?
+        Wizards::Steps::MembershipTerminatedInfo.step_name
+      elsif person.sac_membership_family? && !(person.sac_family_main_person? || backoffice?)
+        Wizards::Steps::AskFamilyMainPerson.step_name
+      else
+        Wizards::Steps::SwitchStammsektion::ChooseSektion.step_name
+      end
+    end
+  end
+end

--- a/app/models/wizards/steps/switch_stammsektion/choose_date.rb
+++ b/app/models/wizards/steps/switch_stammsektion/choose_date.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Wizards
+  module Steps
+    module SwitchStammsektion
+      class ChooseDate < Step
+        SWITCH_ON_OPTIONS = %w[now next_year].freeze
+        attribute :switch_on, :string
+
+        validates :switch_on, presence: true
+        validates :switch_on, inclusion: {in: SWITCH_ON_OPTIONS}, allow_blank: true
+
+        delegate :human_attribute_name, to: :class
+
+        def switch_on_options
+          SWITCH_ON_OPTIONS.map do |option|
+            [option, human_attribute_name(option)]
+          end
+        end
+
+        def switch_on_text
+          if switch_now?
+            human_attribute_name(:now)
+          else
+            I18n.l(next_year, format: "%d. %B")
+          end
+        end
+
+        def switch_date
+          switch_now? ? now : next_year
+        end
+
+        private
+
+        def now
+          Time.zone.today
+        end
+
+        def next_year
+          Time.zone.now.beginning_of_year.next_year.to_date
+        end
+
+        def switch_now?
+          /now/.match?(switch_on)
+        end
+      end
+    end
+  end
+end

--- a/app/models/wizards/steps/switch_stammsektion/choose_sektion.rb
+++ b/app/models/wizards/steps/switch_stammsektion/choose_sektion.rb
@@ -1,0 +1,19 @@
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Wizards
+  module Steps
+    module SwitchStammsektion
+      class ChooseSektion < Wizards::Steps::ChooseSektion
+        delegate :person, to: :wizard
+        delegate :sac_membership_family?, :household, to: :person
+
+        def family_names
+          household.people.map(&:to_s).to_sentence
+        end
+      end
+    end
+  end
+end

--- a/app/models/wizards/steps/switch_stammsektion/summary.rb
+++ b/app/models/wizards/steps/switch_stammsektion/summary.rb
@@ -1,0 +1,13 @@
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Wizards
+  module Steps
+    module SwitchStammsektion
+      class Summary < Step
+      end
+    end
+  end
+end

--- a/app/views/memberships/switch_stammsektions/_form.html.haml
+++ b/app/views/memberships/switch_stammsektions/_form.html.haml
@@ -1,0 +1,14 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+- @sheet = Sheet::Memberships::SwitchStammsektion.new(self, nil, group)
+
+= standard_form(wizard, url: group_person_switch_stammsektion_path(group_id: group.id, person_id: person.id), data: { controller: 'forwarder'}) do |f| 
+  = render StepsComponent.new(partials: wizard.partials, step: wizard.current_step, form: f) do |c|
+    = c.with_aside do
+      .col-md
+        - if wizard.step(:choose_sektion)&.group
+          = render(SelfRegistration::FeeComponent.new(group: c.model.choose_sektion.group, birthdays: []))
+        = render(SelfRegistration::InfosComponent.new)

--- a/app/views/memberships/switch_stammsektions/show.html.haml
+++ b/app/views/memberships/switch_stammsektions/show.html.haml
@@ -1,0 +1,1 @@
+= render 'form'

--- a/app/views/wizards/steps/switch_stammsektion/_choose_date.html.haml
+++ b/app/views/wizards/steps/switch_stammsektion/_choose_date.html.haml
@@ -1,0 +1,12 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+.alert.alert-info
+  %p=t('.info_text')
+
+= c.fields_for do |form|
+  = form.labeled(:switch_on) do
+    - form.object.switch_on_options.each do |key, label|
+      = form.inline_radio_button :switch_on, key, label

--- a/app/views/wizards/steps/switch_stammsektion/_choose_sektion.html.haml
+++ b/app/views/wizards/steps/switch_stammsektion/_choose_sektion.html.haml
@@ -1,0 +1,10 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+- if c.model.sac_membership_family?
+  .alert.alert-info
+    =t('.family_membership_info_text', family_names: c.model.family_names)
+
+= render 'wizards/steps/choose_sektion', c: c

--- a/app/views/wizards/steps/switch_stammsektion/_summary.html.haml
+++ b/app/views/wizards/steps/switch_stammsektion/_summary.html.haml
@@ -1,0 +1,9 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+-#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito_sac_cas.
+
+
+= c.form_error_messages
+%p=t('.info_text', switch_on: c.model.wizard.choose_date.switch_on_text)
+= c.bottom_toolbar

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -8,7 +8,6 @@ de:
     phone_placeholder: +41 77 123 45 67
     currency: CHF
     years: Jahre
-
     wizards/steps/membership_terminated_info_title: Mitgliedschaft gekündet
     wizards/steps/choose_membership_title: Familienmitgliedschaft
     wizards/steps/choose_sektion_title: Sektion wählen
@@ -18,6 +17,9 @@ de:
     wizards/steps/leave_zusatzsektion/ask_family_main_person_title: Familienmitgliedschaft
     wizards/steps/leave_zusatzsektion/summary_title: Bestätigung
     wizards/steps/termination/summary_title: Bestätigung
+    wizards/steps/switch_stammsektion/summary_title: Bestätigung
+    wizards/steps/switch_stammsektion/choose_date_title: Datumwahl
+    wizards/steps/switch_stammsektion/choose_sektion_title: Sektion wählen
 
   errors:
     messages:
@@ -32,6 +34,10 @@ de:
         register_as: Für wen soll die Zusatzmitgliedschaft gelten?
         family: für die ganze Familie
         myself: für mich selbst
+      wizards/steps/switch_stammsektion/choose_date:
+        switch_on: Startdatum
+        now: sofort
+        next_year: auf 1. Januar
       memberships/join_base:
         join_date: Beitrittsdatum
       memberships/leave_zusatzsektion:
@@ -842,7 +848,8 @@ de:
   dropdown/people/memberships:
     title: Mitgliedschaft anpassen
     join_zusatzsektion_link: Zusatzsektion beantragen
-    sac_membership_termination_link: SAC-Mitgliedschaft beenden
+    switch_stammsektion_link: Sektionswechsel beantragen
+    terminate_sac_membership_wizard_link: SAC-Mitgliedschaft beenden
 
   dropdown/people_export:
     recipients: Empfänger
@@ -1183,6 +1190,11 @@ de:
         success:
           one: "Deine Zusatzmitgliedschaft in <i>%{group_name}</i> wurde gelöscht."
           other: "Eure %{count} Zusatzmitgliedschaften in <i>%{group_name}</i> wurden gelöscht."
+    switch_stammsektions:
+      create:
+        success:
+          one: "Dein Sektionswechsel zu <i>%{group_name}</i> wurde per <i>%{switch_date}</i> vorgenommen."
+          other: "Eure %{count} Sektionswechsel zu <i>%{group_name}</i> wurde per <i>%{switch_date}</i> vorgenommen."
 
   roles:
     beitragskategorie:
@@ -1331,6 +1343,9 @@ de:
   sheet/memberships/leave_zusatzsektion:
     title: Zusatzsektion verlassen
 
+  sheet/memberships/switch_stammsektion:
+    title: Stammsektion wechseln
+
   sheet/memberships/terminate_sac_membership:
     title: SAC-Mitgliedschaft beenden
 
@@ -1349,6 +1364,16 @@ de:
           Falls die Zusatzmitgliedschaft für die ganze Familie gelten soll,
           muss die Familienhauptperson diese abschliessen. Wende dich dafür an
           %{name}.
+      switch_stammsektion:
+        choose_sektion:
+          family_membership_info_text: >-
+            Achtung: Der Stammsektionsektionswechsel wird für die gesamte Familienmitgliedschaft
+            beantragt. Davon betroffen sind: %{family_names}
+        choose_date:
+          info_text: Wann soll der Sektionswechsel stattfinden?
+        summary:
+          info_text: 'Der Wechsel der Stammsektion wird per %{switch_on} vorgenommen.'
+          next_button: Kostenpflichtig bestellen
       join_zusatzsektion:
         summary:
           info_text: 'Die Mitgliedschaft bei der Zusatzsektion wird als
@@ -1364,7 +1389,7 @@ Allenfalls musst du den Austritt vorgängig mit der Sektion abklären."
       termination_no_self_service:
         info_text: "Wir bitten dich den Austritt telefonisch oder per E-Mail zu beantragen. Nimm dazu bitte Kontakt mit uns auf."
       ask_family_main_person:
-          info_text: "Der Austritt aus der Zusatzsektion kann nur für die gesamte Familienmitgliedschaft beantragt werden und muss von der Hauptperson in deiner Familienmitgliedschaft angefragt werden. Bitte wende dich an %{family_main_person}."
+        info_text: "Der Austritt aus der Zusatzsektion kann nur für die gesamte Familienmitgliedschaft beantragt werden und muss von der Hauptperson in deiner Familienmitgliedschaft angefragt werden. Bitte wende dich an %{family_main_person}."
       leave_zusatzsektion:
         summary:
           family_warning: "Achtung: Der Austritt aus der Zusatzsektion wird für die gesamte Familienmitgliedschaft beantragt.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
         resources :membership_invoices, only: [:create], module: :people
         resources :sac_remarks, only: %i[index edit update], module: :person
         resource :join_zusatzsektion, module: :memberships, only: [:show, :create]
+        resource :switch_stammsektion, module: :memberships, only: [:show, :create]
         resource :terminate_sac_membership, only: [:show, :create], module: :people
         resources :roles, only: [] do
           resource :leave_zusatzsektion, module: :memberships, only: [:show, :create]

--- a/db/seeds/custom_contents.rb
+++ b/db/seeds/custom_contents.rb
@@ -12,8 +12,9 @@ CustomContent.seed_once(:key,
   { key: Qualifications::ExpirationMailer::REMINDER_TODAY },
   { key: Qualifications::ExpirationMailer::REMINDER_NEXT_YEAR },
   { key: Qualifications::ExpirationMailer::REMINDER_YEAR_AFTER_NEXT_YEAR },
-  { key: Memberships::LeaveZusatzsektionMailer::CONFIRMATION, placeholders_required: 'person-name, sektion-name, terminate-on'  },
-  { key: Memberships::TerminateSacMembershipMailer::CONFIRMATION, placeholders_required: 'person-name, sektion-name, terminate-on'  }
+  { key: Memberships::LeaveZusatzsektionMailer::CONFIRMATION, placeholders_required: 'person-name, sektion-name, terminate-on' },
+  { key: Memberships::TerminateSacMembershipMailer::CONFIRMATION, placeholders_required: 'person-name, sektion-name, terminate-on' },
+  { key: Memberships::SwitchStammsektionMailer::CONFIRMATION, placeholders_required: 'person-name, group-name, switch-date' }
 )
 
 participation_rejected_id =
@@ -70,5 +71,12 @@ CustomContent::Translation.seed_once(:custom_content_id, :locale,
     subject: 'Der SAC Austritt wurde per {terminate-on} vorgenommen',
     body: 'Hallo {person-name},<br/><br/>' \
     'Der SAC Austritt wurde per {terminate-on} vorgenommen.'
+  },
+ { custom_content_id: CustomContent.get(Memberships::SwitchStammsektionMailer::CONFIRMATION).id,
+    locale: 'de',
+    label: 'Mitgliedschaften: Bestätigung Sektionswechsel',
+    subject: 'Bestätigung Sektionswechsel',
+    body: 'Hallo {person-name}<br/><br/>,' \
+    'Der Sektionswechsel zu {group-name} wurde per {switch-date} vorgenommen.'
   }
 )

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -83,6 +83,7 @@ module HitobitoSacCas
       Ability.store.register Memberships::JoinZusatzsektionAbility
       Ability.store.register Memberships::LeaveZusatzsektionAbility
       Ability.store.register Memberships::TerminateSacMembershipAbility
+      Ability.store.register Memberships::SwitchStammsektionAbility
       AbilityDsl::Base.prepend SacCas::AbilityDsl::Base
       Event::ParticipationAbility.prepend SacCas::Event::ParticipationAbility
       GroupAbility.prepend SacCas::GroupAbility

--- a/spec/controllers/memberships/switch_stammsektions_controller_spec.rb
+++ b/spec/controllers/memberships/switch_stammsektions_controller_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Memberships::SwitchStammsektionsController do
+  let(:current_user) { people(:admin) }
+  let(:person) { people(:mitglied) }
+  let(:matterhorn) { groups(:matterhorn) }
+  let(:stammsektion_role) { person.sac_membership.stammsektion_role }
+
+  def wizard_params(step: 0, **attrs)
+    {
+      group_id: stammsektion_role.group_id,
+      person_id: person.id,
+      step: step
+    }.merge(wizards_memberships_switch_stammsektion: attrs)
+  end
+
+  before { sign_in(current_user) }
+
+  context "single person" do
+    before { roles(:mitglied_zweitsektion).destroy }
+
+    it "response with 422 when flash message" do
+      post :create, params: wizard_params(choose_sektion: {group_id: groups(:root).id})
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "sets flash message" do
+      post :create, params: wizard_params(step: 2, choose_sektion: {group_id: matterhorn.id}, choose_date: {switch_on: :now})
+      expect(response).to redirect_to(person_path(person, format: :html))
+      expect(flash[:notice]).to eq "Dein Sektionswechsel zu <i>SAC Matterhorn</i> wurde per <i>sofort</i> vorgenommen."
+    end
+  end
+
+  context "family" do
+    let(:person) { people(:familienmitglied) }
+
+    it "sets flash message" do
+      roles(:familienmitglied_zweitsektion).destroy
+      roles(:familienmitglied2_zweitsektion).destroy
+
+      post :create, params: wizard_params(step: 2, choose_sektion: {group_id: matterhorn.id}, choose_date: {switch_on: :now})
+      expect(response).to redirect_to(person_path(person, format: :html))
+      expect(flash[:notice]).to eq "Eure 3 Sektionswechsel zu <i>SAC Matterhorn</i> wurde per <i>sofort</i> vorgenommen."
+    end
+  end
+end

--- a/spec/features/memberships/switch_stammsektion_spec.rb
+++ b/spec/features/memberships/switch_stammsektion_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2012-2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe "switching stammsektion", js: true do
+  before do
+    sign_in(person)
+    visit group_person_path(group_id: group.id, id: person.id)
+
+    Group::SektionsNeuanmeldungenSektion.delete_all # To allow self service
+  end
+
+  context "as normal user" do
+    let(:group) { groups(:bluemlisalp_mitglieder) }
+    let(:person) { people(:mitglied) }
+
+    before do
+      roles(:mitglied_zweitsektion).destroy
+    end
+
+    it "can open wizard via dropdown" do
+      visit group_person_path(group_id: group.id, id: person.id)
+      click_link "Mitgliedschaft anpassen"
+      click_link "Sektionswechsel beantragen"
+    end
+
+    it "fills out form and redirects" do
+      click_link "Mitgliedschaft anpassen"
+      click_link "Sektionswechsel beantragen"
+      expect(page).to have_css "h1", text: "Stammsektion wechseln"
+      expect(page).to have_css "li.active", text: "Sektion wählen"
+      select "SAC Matterhorn"
+      click_on "Weiter"
+      expect(page).to have_css "li.active", text: "Datumwahl"
+      expect(page).to have_css ".alert-info", text: "Wann soll der Sektionswechsel stattfinden?"
+      choose "sofort"
+      click_on "Weiter"
+      expect(page).to have_css "li.active", text: "Bestätigung"
+      expect(page).to have_content "Beiträge in der Sektion SAC Matterhorn"
+      click_on "Kostenpflichtig bestellen"
+      expect(page).to have_css "#flash .alert-success",
+        text: "Dein Sektionswechsel zu SAC Matterhorn wurde per sofort vorgenommen."
+    end
+  end
+
+  context "as family user" do
+    let(:group) { groups(:bluemlisalp_mitglieder) }
+    let(:person) { people(:familienmitglied) }
+
+    before do
+      roles(:familienmitglied_zweitsektion).destroy
+      roles(:familienmitglied_zweitsektion).destroy
+    end
+
+    it "can switch for all members" do
+      click_link "Mitgliedschaft anpassen"
+      click_link "Sektionswechsel beantragen"
+      expect(page).to have_css "li.active", text: "Sektion wählen"
+      expect(page).to have_css ".alert-info", text: "Achtung: Der Stammsektionsektionswechsel wird für die gesamte Familienmitgliedschaft beantragt. " \
+        "Davon betroffen sind: Tenzing Norgay, Frieda Norgay und Nima Norgay"
+      select "SAC Matterhorn"
+      click_on "Weiter"
+      expect(page).to have_css "li.active", text: "Datumwahl"
+      expect(page).to have_css ".alert-info", text: "Wann soll der Sektionswechsel stattfinden?"
+      choose "auf 1. Januar"
+      click_on "Weiter"
+      expect(page).to have_css "li.active", text: "Bestätigung"
+      expect(page).to have_content "Beiträge in der Sektion SAC Matterhorn"
+      expect do
+        click_on "Kostenpflichtig bestellen"
+        expect(page).to have_css "#flash .alert-success", text: "Eure 3 Sektionswechsel zu SAC Matterhorn wurde per 01. Januar vorgenommen."
+      end.to change { Role.count }.by(3)
+    end
+  end
+end

--- a/spec/helpers/dropdown/people/memberships_spec.rb
+++ b/spec/helpers/dropdown/people/memberships_spec.rb
@@ -29,21 +29,59 @@ describe Dropdown::People::Memberships do
 
   def menu = subject.find(".btn-group > ul.dropdown-menu")
 
-  it "does not render any buttons when person is not permitted" do
+  def stub_can_create(wizard_class, value)
     expect(ability).to receive(:can?).with(:create,
-      kind_of(Wizards::Memberships::TerminateSacMembershipWizard)).and_return(false)
-    expect(ability).to receive(:can?).with(:create,
-      kind_of(Wizards::Memberships::JoinZusatzsektion)).and_return(false)
-    expect(dropdown.to_s).to be_blank
+      kind_of(wizard_class)).and_return(value)
   end
 
-  it "does render buttons when person is permitted" do
-    expect(ability).to receive(:can?).with(:create,
-      kind_of(Wizards::Memberships::TerminateSacMembershipWizard)).and_return(true)
-    expect(ability).to receive(:can?).with(:create,
-      kind_of(Wizards::Memberships::JoinZusatzsektion)).and_return(true)
-    expect(dropdown.to_s).to be_present
-    expect(menu).to have_link "Zusatzsektion beantragen"
-    expect(menu).to have_link "SAC-Mitgliedschaft beenden"
+  context "JoinZusatzsektion" do
+    before do
+      stub_can_create(Wizards::Memberships::SwitchStammsektion, false)
+      stub_can_create(Wizards::Memberships::TerminateSacMembershipWizard, false)
+    end
+
+    it "is empty when person is not permitted" do
+      stub_can_create(Wizards::Memberships::JoinZusatzsektion, false)
+      expect(dropdown.to_s).to be_blank
+    end
+
+    it "is contains links if person is permitted" do
+      stub_can_create(Wizards::Memberships::JoinZusatzsektion, true)
+      expect(menu).to have_link "Zusatzsektion beantragen"
+    end
+  end
+
+  context "SwitchStammsektion" do
+    before do
+      stub_can_create(Wizards::Memberships::JoinZusatzsektion, false)
+      stub_can_create(Wizards::Memberships::TerminateSacMembershipWizard, false)
+    end
+
+    it "is empty when person is not permitted" do
+      stub_can_create(Wizards::Memberships::SwitchStammsektion, false)
+      expect(dropdown.to_s).to be_blank
+    end
+
+    it "is contains links if person is permitted" do
+      stub_can_create(Wizards::Memberships::SwitchStammsektion, true)
+      expect(menu).to have_link "Sektionswechsel beantragen"
+    end
+  end
+
+  context "TerminateSacMembershipWizard" do
+    before do
+      stub_can_create(Wizards::Memberships::JoinZusatzsektion, false)
+      stub_can_create(Wizards::Memberships::SwitchStammsektion, false)
+    end
+
+    it "is empty when person is not permitted" do
+      stub_can_create(Wizards::Memberships::TerminateSacMembershipWizard, false)
+      expect(dropdown.to_s).to be_blank
+    end
+
+    it "is contains links if person is permitted" do
+      stub_can_create(Wizards::Memberships::TerminateSacMembershipWizard, true)
+      expect(menu).to have_link "SAC-Mitgliedschaft beenden"
+    end
   end
 end

--- a/spec/mailers/memberships/switch_stammsektion_mailer_spec.rb
+++ b/spec/mailers/memberships/switch_stammsektion_mailer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+#
+require "spec_helper"
+
+describe Memberships::SwitchStammsektionMailer do
+  let(:person) { people(:admin) }
+  let(:group) { groups(:bluemlisalp) }
+  let(:switch_on) { "sofort" }
+  let(:mail) { described_class.confirmation(person, group, switch_on) }
+
+  subject { mail.parts.first.body }
+
+  it "sends confirmation email to person" do
+    expect(mail.to).to match_array(["support@hitobito.example.com"])
+    expect(mail.subject).to eq "Bestätigung Sektionswechsel"
+    expect(mail.body).to match("Hallo Anna Admin")
+    expect(mail.body).to match("Der Sektionswechsel zu SAC Blüemlisalp wurde per sofort vorgenommen.")
+  end
+
+  it "sends confirmation email to geschaefsstelle if configured" do
+    groups(:geschaeftsstelle).update!(email: "geschaeftsstelle@example.com")
+    expect(mail.cc).to eq ["geschaeftsstelle@example.com"]
+  end
+end

--- a/spec/models/memberships/switch_stammsektion_spec.rb
+++ b/spec/models/memberships/switch_stammsektion_spec.rb
@@ -120,6 +120,7 @@ describe Memberships::SwitchStammsektion do
         expect(bluemlisalp_mitglied.reload.deleted_at).to eq now.yesterday.end_of_day.to_s(:db)
         expect(matterhorn_mitglied.created_at).to eq now.to_s(:db)
         expect(matterhorn_mitglied.delete_on).to eq now.end_of_year.to_date
+        expect(person.primary_group).to eq matterhorn_mitglieder
       end
 
       context "switching next year" do

--- a/spec/models/wizards/memberships/switch_stammsektion_spec.rb
+++ b/spec/models/wizards/memberships/switch_stammsektion_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Wizards::Memberships::SwitchStammsektion do
+  let(:backoffice) { false }
+  let(:matterhorn) { groups(:matterhorn) }
+  let(:bluemlisalp) { groups(:bluemlisalp) }
+  let(:params) { {} }
+  let(:stammsektion_role) { person.sac_membership.stammsektion_role }
+  let(:email) {
+    Delayed::Job.last.payload_object.perform
+    ActionMailer::Base.deliveries.first
+  }
+
+  let(:wizard) do
+    described_class.new(current_step: @current_step.to_i, backoffice:, person:, **params)
+  end
+
+  context "single person" do
+    let(:person) { people(:mitglied) }
+
+    it "has three steps" do
+      expect(wizard.step_at(0)).to be_kind_of(Wizards::Steps::ChooseSektion)
+      expect(wizard.step_at(0)).to be_instance_of(Wizards::Steps::SwitchStammsektion::ChooseSektion)
+      expect(wizard.step_at(1)).to be_instance_of(Wizards::Steps::SwitchStammsektion::ChooseDate)
+      expect(wizard.step_at(2)).to be_instance_of(Wizards::Steps::SwitchStammsektion::Summary)
+    end
+
+    it "has only MembershipTerminatedInfo step if stammsektion_role is terminated" do
+      stammsektion_role.update_column(:terminated, true)
+      expect(wizard.step_at(0)).to be_instance_of(Wizards::Steps::MembershipTerminatedInfo)
+      expect(wizard.step_at(1)).to be_nil
+    end
+
+    describe "persisting" do
+      let(:backoffice) { true }
+
+      before do
+        @current_step = 2
+        params["choose_sektion"] = {group_id: matterhorn.id}
+        params["choose_date"] = {switch_on: :now}
+        expect(wizard).to be_last_step
+        roles(:mitglied_zweitsektion).destroy
+      end
+
+      it "switches stammsektion and sends email" do
+        expect(wizard).to be_last_step
+        expect { expect(wizard.save!).to eq true }
+          .to change { person.sac_membership.stammsektion_role.group.parent.name }
+          .from("SAC Blüemlisalp").to("SAC Matterhorn")
+          .and not_change { Role.count }
+
+        expect(email.subject).to eq("Bestätigung Sektionswechsel")
+        expect(email.body).to match(/Hallo Edmund Hillary/)
+        expect(email.body).to match(/Sektionswechsel zu SAC Matterhorn wurde per sofort/)
+      end
+    end
+  end
+
+  context "household" do
+    let(:familienmitglied2) { people(:familienmitglied2) }
+
+    context "for main person" do
+      let(:person) { people(:familienmitglied) }
+
+      it "has three steps" do
+        expect(wizard.step_at(0)).to be_instance_of(Wizards::Steps::SwitchStammsektion::ChooseSektion)
+        expect(wizard.step_at(1)).to be_instance_of(Wizards::Steps::SwitchStammsektion::ChooseDate)
+        expect(wizard.step_at(2)).to be_instance_of(Wizards::Steps::SwitchStammsektion::Summary)
+      end
+
+      it "has only MembershipTerminatedInfo step if stammsektion_role is terminated" do
+        stammsektion_role.update_column(:terminated, true)
+        expect(wizard.step_at(0)).to be_instance_of(Wizards::Steps::MembershipTerminatedInfo)
+        expect(wizard.step_at(1)).to be_nil
+      end
+    end
+
+    context "for other person" do
+      let(:person) { familienmitglied2 }
+
+      it "only has the AskFamilyMainPerson step" do
+        expect(wizard.step_at(0)).to be_instance_of(Wizards::Steps::AskFamilyMainPerson)
+      end
+
+      context "when operator is backoffice" do
+        let(:backoffice) { true }
+
+        it "includes the backoffice steps" do
+          expect(wizard.step_at(0)).to be_instance_of(Wizards::Steps::SwitchStammsektion::ChooseSektion)
+        end
+      end
+    end
+
+    describe "persisting" do
+      let(:backoffice) { true }
+
+      before do
+        @current_step = 2
+        params["choose_sektion"] = {group_id: matterhorn.id}
+        params["choose_date"] = {switch_on: :now}
+        expect(wizard).to be_last_step
+        roles(:familienmitglied_zweitsektion).destroy
+        roles(:familienmitglied2_zweitsektion).destroy
+      end
+
+      context "for main person" do
+        let(:person) { people(:familienmitglied) }
+
+        it "switches stammsektion and sends email" do
+          expect { expect(wizard.save!).to eq true }
+            .to change { person.sac_membership.stammsektion_role.group.parent.name }
+            .from("SAC Blüemlisalp").to("SAC Matterhorn")
+            .and change { familienmitglied2.sac_membership.stammsektion_role.group.parent.name }
+            .from("SAC Blüemlisalp").to("SAC Matterhorn")
+            .and not_change { Role.count }
+
+          expect(email.subject).to eq("Bestätigung Sektionswechsel")
+          expect(email.body).to match(/Hallo Tenzing Norgay/)
+          expect(email.body).to match(/Sektionswechsel zu SAC Matterhorn wurde per sofort/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref: #605

Erster Wurf vom Stammsektions Wechsel wizard, der happy path funktioniert, weiteres manuelles testen und ergänzen von cases wäre super.

Folgendes ist mir noch aufgefallen 
- Damit der Benutzer wieder richtig angezeigt wird (nach dem redirect) musstes ich die `primary_group` neu setzen. Scheinbar ein grundsätzliches Problem, ist auch bei  `JoinZusatzsektion` aufgefallen
- Wechseln per sofort von A zu B zu A tut nicht. Ursache scheint die Rolle die für B angelegt wird (mit start datum vom aktuellen Tag), die schlägt dann auf der letzten Seite (`operation#valid?`) an. Mir ist nicht klar wie es sich da verhalten soll. 

Die spezifizierte Anpassung am `Roles::TerminateRoleLink#render_link` ist nicht umgesetzt, bzw hab ich nicht verstanden, ist die Beschreibung da vielleicht falsch?


