### PR TITLE
Quote tablename for groups

### DIFF
--- a/db/migrate/20240522065606_delete_obsolete_roles_and_groups.rb
+++ b/db/migrate/20240522065606_delete_obsolete_roles_and_groups.rb
@@ -13,15 +13,15 @@ class DeleteObsoleteRolesAndGroups < ActiveRecord::Migration[6.1]
     execute "DELETE FROM roles WHERE type='Group::SektionsFunktionaere::Kulturbeauftragte'"
 
     execute <<~SQL
-      DELETE groups FROM groups
-      INNER JOIN groups g1 ON groups.layer_group_id = g1.id AND g1.type = 'Group::SacCas'
-      AND groups.type = 'Group::ExterneKontakte'
+      DELETE `groups` FROM `groups`
+      INNER JOIN `groups` g1 ON `groups`.layer_group_id = g1.id AND g1.type = 'Group::SacCas'
+      AND `groups`.type = 'Group::ExterneKontakte'
     SQL
 
     execute <<~SQL
       DELETE roles FROM roles
-      LEFT JOIN groups ON roles.group_id = groups.id
-      WHERE groups.id IS NULL
+      LEFT JOIN `groups` ON roles.group_id = `groups`.id
+      WHERE `groups`.id IS NULL
     SQL
   end
 end

--- a/db/migrate/20240529120000_move_huetten_into_sektionsfunktionaere.rb
+++ b/db/migrate/20240529120000_move_huetten_into_sektionsfunktionaere.rb
@@ -10,10 +10,10 @@ class MoveHuettenIntoSektionsfunktionaere < ActiveRecord::Migration[6.1]
     return unless connection.adapter_name =~ /mysql/i
 
     # Move each SektionsHuettenkommission group into its sibling SektionsFunktionaere
-    execute "UPDATE groups AS huetten SET parent_id=(SELECT funktionaere.id FROM (SELECT id, parent_id from groups WHERE type = 'Group::SektionsFunktionaere') funktionaere WHERE funktionaere.parent_id = huetten.parent_id LIMIT 1) WHERE type='Group::SektionsHuettenkommission'"
+    execute "UPDATE `groups` AS huetten SET parent_id=(SELECT funktionaere.id FROM (SELECT id, parent_id from `groups` WHERE type = 'Group::SektionsFunktionaere') funktionaere WHERE funktionaere.parent_id = huetten.parent_id LIMIT 1) WHERE type='Group::SektionsHuettenkommission'"
 
     # Rebuild the whole group hierarchy
-    execute "UPDATE groups SET lft=NULL, rgt=NULL"
+    execute "UPDATE `groups` SET lft=NULL, rgt=NULL"
     old_value = Group.archival_validation
     Group.archival_validation = false
     Group.rebuild!

--- a/db/migrate/20240605120000_move_more_groups_into_sektionsfunktionaere.rb
+++ b/db/migrate/20240605120000_move_more_groups_into_sektionsfunktionaere.rb
@@ -7,10 +7,10 @@
 
 class MoveMoreGroupsIntoSektionsfunktionaere < ActiveRecord::Migration[6.1]
   def up
-    return unless connection.adapter_name =~ /mysql/i
+    return unless /mysql/i.match?(connection.adapter_name)
 
-    say_with_time('creating missing default_children of Sektion groups') do
-      Group.where(type: 'Group::Sektion').find_each do |group|
+    say_with_time("creating missing default_children of Sektion groups") do
+      Group.where(type: "Group::Sektion").find_each do |group|
         group.default_children.each do |group_type|
           next if group.children.where(type: group_type).exists?
           child = group_type.new(name: group_type.label)
@@ -23,23 +23,23 @@ class MoveMoreGroupsIntoSektionsfunktionaere < ActiveRecord::Migration[6.1]
     # Now that we can be sure that every Sektion has a SektionsFunktionaere subgroup...
 
     # Move each SektionsTourenkommission group into its sibling SektionsFunktionaere
-    execute "UPDATE groups AS tourenundkurse SET parent_id=COALESCE((SELECT funktionaere.id FROM (SELECT id, parent_id from groups WHERE type = 'Group::SektionsFunktionaere') funktionaere WHERE funktionaere.parent_id = tourenundkurse.parent_id LIMIT 1), tourenundkurse.parent_id) WHERE type='Group::SektionsTourenkommission'"
+    execute "UPDATE `groups` AS tourenundkurse SET parent_id=COALESCE((SELECT funktionaere.id FROM (SELECT id, parent_id from `groups` WHERE type = 'Group::SektionsFunktionaere') funktionaere WHERE funktionaere.parent_id = tourenundkurse.parent_id LIMIT 1), tourenundkurse.parent_id) WHERE type='Group::SektionsTourenkommission'"
 
     # Move each SektionsKommission group into its sibling SektionsFunktionaere
-    execute "UPDATE groups AS kommissionen SET parent_id=COALESCE((SELECT funktionaere.id FROM (SELECT id, parent_id from groups WHERE type = 'Group::SektionsFunktionaere') funktionaere WHERE funktionaere.parent_id = kommissionen.parent_id LIMIT 1), kommissionen.parent_id) WHERE type='Group::SektionsKommission'"
+    execute "UPDATE `groups` AS kommissionen SET parent_id=COALESCE((SELECT funktionaere.id FROM (SELECT id, parent_id from `groups` WHERE type = 'Group::SektionsFunktionaere') funktionaere WHERE funktionaere.parent_id = kommissionen.parent_id LIMIT 1), kommissionen.parent_id) WHERE type='Group::SektionsKommission'"
 
     # Move each SektionsVorstand group into its sibling SektionsFunktionaere
-    execute "UPDATE groups AS vorstand SET parent_id=COALESCE((SELECT funktionaere.id FROM (SELECT id, parent_id from groups WHERE type = 'Group::SektionsFunktionaere') funktionaere WHERE funktionaere.parent_id = vorstand.parent_id LIMIT 1), vorstand.parent_id) WHERE type='Group::SektionsVorstand'"
+    execute "UPDATE `groups` AS vorstand SET parent_id=COALESCE((SELECT funktionaere.id FROM (SELECT id, parent_id from `groups` WHERE type = 'Group::SektionsFunktionaere') funktionaere WHERE funktionaere.parent_id = vorstand.parent_id LIMIT 1), vorstand.parent_id) WHERE type='Group::SektionsVorstand'"
 
     # Rebuild the whole group hierarchy
-    execute "UPDATE groups SET lft=NULL, rgt=NULL"
+    execute "UPDATE `groups` SET lft=NULL, rgt=NULL"
     old_value = Group.archival_validation
     Group.archival_validation = false
     Group.rebuild!
     Group.archival_validation = old_value
 
-    say_with_time('creating missing default_children of SektionsFunktionaere groups') do
-      Group.where(type: 'Group::SektionsFunktionaere').find_each do |group|
+    say_with_time("creating missing default_children of SektionsFunktionaere groups") do
+      Group.where(type: "Group::SektionsFunktionaere").find_each do |group|
         group.default_children.each do |group_type|
           next if group.children.where(type: group_type).exists?
           child = group_type.new(name: group_type.label)


### PR DESCRIPTION
This help to distinguish between the SQL-literal GROUPS and the table-name for Group-Objects. Not strictly needed for the current version of mysql in production, but I do not want to be surprised be this.