### PR TITLE
EVENTS: Einstellungen Kursvergütungskategorien

### DIFF
--- a/app/abilities/course_compensation_category_ability.rb
+++ b/app/abilities/course_compensation_category_ability.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+class CourseCompensationCategoryAbility < AbilityDsl::Base
+  on(CourseCompensationCategory) do
+    class_side(:index, :create).if_admin
+    permission(:admin).may(:manage).all
+  end
+end

--- a/app/controllers/course_compensation_categories_controller.rb
+++ b/app/controllers/course_compensation_categories_controller.rb
@@ -6,7 +6,7 @@
 #  https://github.com/hitobito/hitobito_sac_cas
 
 class CourseCompensationCategoriesController < SimpleCrudController
-  self.permitted_attrs = []
+  self.permitted_attrs = [:short_name, :kind, :description, :name_leader, :name_assistant_leader]
 
   private
 

--- a/app/controllers/course_compensation_categories_controller.rb
+++ b/app/controllers/course_compensation_categories_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+class CourseCompensationCategoriesController < SimpleCrudController
+  self.permitted_attrs = []
+end

--- a/app/controllers/course_compensation_categories_controller.rb
+++ b/app/controllers/course_compensation_categories_controller.rb
@@ -7,4 +7,10 @@
 
 class CourseCompensationCategoriesController < SimpleCrudController
   self.permitted_attrs = []
+
+  private
+
+  def list_entries
+    super.list
+  end
 end

--- a/app/helpers/sheet/course_compensation_category.rb
+++ b/app/helpers/sheet/course_compensation_category.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+module Sheet
+  class CourseCompensationCategory < Sheet::Admin; end
+end

--- a/app/models/course_compensation_category.rb
+++ b/app/models/course_compensation_category.rb
@@ -26,6 +26,8 @@ class CourseCompensationCategory < ApplicationRecord
   include I18nEnums
   include CapitalizedDependentErrors
 
+  validates_by_schema
+
   has_many :course_compensation_rates, dependent: :restrict_with_error
   translates :name_leader, :name_assistant_leader
 
@@ -33,9 +35,6 @@ class CourseCompensationCategory < ApplicationRecord
   i18n_enum :kind, KINDS
 
   scope :list, -> { order(:short_name) }
-
-  validates :short_name, presence: true
-  validates :kind, presence: true
 
   def to_s
     "#{short_name} (#{kind_label})"

--- a/app/models/course_compensation_category.rb
+++ b/app/models/course_compensation_category.rb
@@ -34,6 +34,9 @@ class CourseCompensationCategory < ApplicationRecord
 
   scope :list, -> { order(:short_name) }
 
+  validates :short_name, presence: true
+  validates :kind, presence: true
+
   def to_s
     "#{short_name} (#{kind_label})"
   end

--- a/app/models/course_compensation_category.rb
+++ b/app/models/course_compensation_category.rb
@@ -32,6 +32,8 @@ class CourseCompensationCategory < ApplicationRecord
   KINDS = %w[day flat budget]
   i18n_enum :kind, KINDS
 
+  scope :list, -> { order(:short_name) }
+
   def to_s
     "#{short_name} (#{kind_label})"
   end

--- a/app/models/course_compensation_category.rb
+++ b/app/models/course_compensation_category.rb
@@ -5,6 +5,23 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas
 
+# == Schema Information
+#
+# Table name: course_compensation_categories
+#
+#  id                    :bigint           not null, primary key
+#  description           :string(255)
+#  kind                  :string(255)      default("day"), not null
+#  name_assistant_leader :string(255)      not null
+#  name_leader           :string(255)      not null
+#  short_name            :string(255)      not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#
+# Indexes
+#
+#  index_course_compensation_categories_on_short_name  (short_name) UNIQUE
+#
 class CourseCompensationCategory < ApplicationRecord
   include I18nEnums
   include CapitalizedDependentErrors

--- a/app/models/course_compensation_rate.rb
+++ b/app/models/course_compensation_rate.rb
@@ -5,6 +5,24 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas
 
+# == Schema Information
+#
+# Table name: course_compensation_rates
+#
+#  id                              :bigint           not null, primary key
+#  rate_assistant_leader           :decimal(7, 2)    not null
+#  rate_leader                     :decimal(7, 2)    not null
+#  valid_from                      :date             not null
+#  valid_to                        :date
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  course_compensation_category_id :bigint           not null
+#
+# Indexes
+#
+#  course_compensation_rate_on_category_id  (course_compensation_category_id)
+#
+
 class CourseCompensationRate < ApplicationRecord
   belongs_to :course_compensation_category
 

--- a/app/models/event/level.rb
+++ b/app/models/event/level.rb
@@ -9,12 +9,15 @@
 #
 # Table name: event_levels
 #
-#  id         :bigint           not null, primary key
-#  code       :integer          not null
-#  deleted_at :datetime
-#  difficulty :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :bigint           not null, primary key
+#  code        :integer          not null
+#  deleted_at  :datetime
+#  description :text(65535)
+#  difficulty  :integer          not null
+#  label       :string(255)      not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 
 class Event::Level < ActiveRecord::Base
   include Paranoia::Globalized

--- a/app/models/external_invoice.rb
+++ b/app/models/external_invoice.rb
@@ -5,6 +5,29 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas
 
+# == Schema Information
+#
+# Table name: external_invoices
+#
+#  id                     :bigint           not null, primary key
+#  abacus_sales_order_key :integer
+#  issued_at              :date
+#  link_type              :string(255)
+#  sent_at                :date
+#  state                  :string(255)      default("draft"), not null
+#  total                  :decimal(12, 2)   default(0.0), not null
+#  type                   :string(255)      not null
+#  year                   :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  link_id                :bigint
+#  person_id              :bigint           not null
+#
+# Indexes
+#
+#  index_external_invoices_on_link       (link_type,link_id)
+#  index_external_invoices_on_person_id  (person_id)
+#
 class ExternalInvoice < ActiveRecord::Base
   STATES = %w[draft open payed cancelled error]
 

--- a/app/models/external_invoice/course.rb
+++ b/app/models/external_invoice/course.rb
@@ -5,6 +5,29 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas
 
+# == Schema Information
+#
+# Table name: external_invoices
+#
+#  id                     :bigint           not null, primary key
+#  abacus_sales_order_key :integer
+#  issued_at              :date
+#  link_type              :string(255)
+#  sent_at                :date
+#  state                  :string(255)      default("draft"), not null
+#  total                  :decimal(12, 2)   default(0.0), not null
+#  type                   :string(255)      not null
+#  year                   :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  link_id                :bigint
+#  person_id              :bigint           not null
+#
+# Indexes
+#
+#  index_external_invoices_on_link       (link_type,link_id)
+#  index_external_invoices_on_person_id  (person_id)
+#
 class ExternalInvoice::Course < ExternalInvoice
   # link is an Event::Participation object for a Event::Course
 end

--- a/app/models/external_invoice/sac_membership.rb
+++ b/app/models/external_invoice/sac_membership.rb
@@ -5,6 +5,29 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas
 
+# == Schema Information
+#
+# Table name: external_invoices
+#
+#  id                     :bigint           not null, primary key
+#  abacus_sales_order_key :integer
+#  issued_at              :date
+#  link_type              :string(255)
+#  sent_at                :date
+#  state                  :string(255)      default("draft"), not null
+#  total                  :decimal(12, 2)   default(0.0), not null
+#  type                   :string(255)      not null
+#  year                   :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  link_id                :bigint
+#  person_id              :bigint           not null
+#
+# Indexes
+#
+#  index_external_invoices_on_link       (link_type,link_id)
+#  index_external_invoices_on_person_id  (person_id)
+#
 class ExternalInvoice::SacMembership < ExternalInvoice
   # link is currently a Group::Section or Group::Ortsgruppe object
   # this is not definitively defined yet, it might become a Role object as well

--- a/app/models/external_training.rb
+++ b/app/models/external_training.rb
@@ -5,6 +5,28 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas
 
+# == Schema Information
+#
+# Table name: external_trainings
+#
+#  id            :bigint           not null, primary key
+#  finish_at     :date             not null
+#  link          :string(255)
+#  name          :string(255)      not null
+#  provider      :string(255)
+#  remarks       :string(255)
+#  start_at      :date             not null
+#  training_days :decimal(5, 1)    not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  event_kind_id :bigint           not null
+#  person_id     :bigint           not null
+#
+# Indexes
+#
+#  index_external_trainings_on_event_kind_id  (event_kind_id)
+#  index_external_trainings_on_person_id      (person_id)
+#
 class ExternalTraining < ActiveRecord::Base
   validates_by_schema
 

--- a/app/models/sac_membership_config.rb
+++ b/app/models/sac_membership_config.rb
@@ -11,13 +11,18 @@
 # Table name: sac_membership_configs
 #
 #  id                                             :bigint           not null, primary key
-#  valid_from                                     :integer          not null
-#  sac_fee_adult                                  :decimal(5, 2)    not null
-#  sac_fee_family                                 :decimal(5, 2)    not null
-#  sac_fee_youth                                  :decimal(5, 2)    not null
+#  balancing_payment_article_number               :string(255)      not null
+#  course_fee_article_number                      :string(255)      not null
+#  discount_date_1                                :string(255)
+#  discount_date_2                                :string(255)
+#  discount_date_3                                :string(255)
+#  discount_percent_1                             :integer
+#  discount_percent_2                             :integer
+#  discount_percent_3                             :integer
 #  entry_fee_adult                                :decimal(5, 2)    not null
 #  entry_fee_family                               :decimal(5, 2)    not null
 #  entry_fee_youth                                :decimal(5, 2)    not null
+#  hut_solidarity_fee_article_number              :string(255)      not null
 #  hut_solidarity_fee_with_hut_adult              :decimal(5, 2)    not null
 #  hut_solidarity_fee_with_hut_family             :decimal(5, 2)    not null
 #  hut_solidarity_fee_with_hut_youth              :decimal(5, 2)    not null
@@ -25,32 +30,29 @@
 #  hut_solidarity_fee_without_hut_family          :decimal(5, 2)    not null
 #  hut_solidarity_fee_without_hut_youth           :decimal(5, 2)    not null
 #  magazine_fee_adult                             :decimal(5, 2)    not null
+#  magazine_fee_article_number                    :string(255)      not null
 #  magazine_fee_family                            :decimal(5, 2)    not null
 #  magazine_fee_youth                             :decimal(5, 2)    not null
-#  service_fee                                    :decimal(5, 2)    not null
 #  magazine_postage_abroad                        :decimal(5, 2)    not null
+#  magazine_postage_abroad_article_number         :string(255)      not null
 #  reduction_amount                               :decimal(5, 2)    not null
 #  reduction_required_membership_years            :integer
-#  discount_date_1                                :string(255)
-#  discount_percent_1                             :integer
-#  discount_date_2                                :string(255)
-#  discount_percent_2                             :integer
-#  discount_date_3                                :string(255)
-#  discount_percent_3                             :integer
-#  sac_fee_article_number                         :string(255)      not null
 #  sac_entry_fee_article_number                   :string(255)      not null
-#  hut_solidarity_fee_article_number              :string(255)      not null
-#  magazine_fee_article_number                    :string(255)      not null
+#  sac_fee_adult                                  :decimal(5, 2)    not null
+#  sac_fee_article_number                         :string(255)      not null
+#  sac_fee_family                                 :decimal(5, 2)    not null
+#  sac_fee_youth                                  :decimal(5, 2)    not null
 #  section_bulletin_postage_abroad_article_number :string(255)      not null
-#  service_fee_article_number                     :string(255)      not null
-#  balancing_payment_article_number               :string(255)      not null
-#  course_fee_article_number                      :string(255)      not null
-#  magazine_postage_abroad_article_number         :string(255)      not null
-#  section_fee_article_number                     :string(255)      not null
 #  section_entry_fee_article_number               :string(255)      not null
+#  section_fee_article_number                     :string(255)      not null
+#  service_fee                                    :decimal(5, 2)    not null
+#  service_fee_article_number                     :string(255)      not null
+#  valid_from                                     :integer          not null
 #
+# Indexes
 #
-
+#  index_sac_membership_configs_on_valid_from  (valid_from) UNIQUE
+#
 class SacMembershipConfig < ApplicationRecord
   class << self
     def active(date = Time.zone.today)

--- a/app/models/sac_section_membership_config.rb
+++ b/app/models/sac_section_membership_config.rb
@@ -9,25 +9,29 @@
 #
 # Table name: sac_section_membership_configs
 #
-#  id                                              :bigint           not null, primary key
-#  valid_from                                      :integer          not null
-#  group_id                                        :bigint
-#  section_fee_adult                               :decimal(5, 2)    not null
-#  section_fee_family                              :decimal(5, 2)    not null
-#  section_fee_youth                               :decimal(5, 2)    not null
-#  section_entry_fee_adult                         :decimal(5, 2)    not null
-#  section_entry_fee_family                        :decimal(5, 2)    not null
-#  section_entry_fee_youth                         :decimal(5, 2)    not null
-#  bulletin_postage_abroad                         :decimal(5, 2)    not null
-#  sac_fee_exemption_for_honorary_members          :boolean          default(FALSE), not null
-#  section_fee_exemption_for_honorary_members      :boolean          default(FALSE), not null
-#  sac_fee_exemption_for_benefited_members         :boolean          default(FALSE), not null
-#  section_fee_exemption_for_benefited_members     :boolean          default(FALSE), not null
-#  reduction_amount                                :decimal(5, 2)    not null
-#  reduction_required_membership_years             :integer
-#  reduction_required_age                          :integer
+#  id                                          :bigint           not null, primary key
+#  bulletin_postage_abroad                     :decimal(5, 2)    not null
+#  reduction_amount                            :decimal(5, 2)    not null
+#  reduction_required_age                      :integer
+#  reduction_required_membership_years         :integer
+#  sac_fee_exemption_for_benefited_members     :boolean          default(FALSE), not null
+#  sac_fee_exemption_for_honorary_members      :boolean          default(FALSE), not null
+#  section_entry_fee_adult                     :decimal(5, 2)    not null
+#  section_entry_fee_family                    :decimal(5, 2)    not null
+#  section_entry_fee_youth                     :decimal(5, 2)    not null
+#  section_fee_adult                           :decimal(5, 2)    not null
+#  section_fee_exemption_for_benefited_members :boolean          default(FALSE), not null
+#  section_fee_exemption_for_honorary_members  :boolean          default(FALSE), not null
+#  section_fee_family                          :decimal(5, 2)    not null
+#  section_fee_youth                           :decimal(5, 2)    not null
+#  valid_from                                  :integer          not null
+#  group_id                                    :bigint           not null
 #
-
+# Indexes
+#
+#  index_sac_section_membership_configs_on_group_id                 (group_id)
+#  index_sac_section_membership_configs_on_group_id_and_valid_from  (group_id,valid_from) UNIQUE
+#
 class SacSectionMembershipConfig < ApplicationRecord
   class << self
     def active(date = Time.zone.today)

--- a/app/models/termination_reason.rb
+++ b/app/models/termination_reason.rb
@@ -5,6 +5,15 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas
 
+# == Schema Information
+#
+# Table name: termination_reasons
+#
+#  id         :bigint           not null, primary key
+#  text       :text(65535)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class TerminationReason < ApplicationRecord
   validates_by_schema
 

--- a/app/views/course_compensation_categories/_form.html.haml
+++ b/app/views/course_compensation_categories/_form.html.haml
@@ -2,3 +2,8 @@
 -#  hitobito and licensed under the Affero General Public License version 3
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito
+
+= entry_form(buttons_bottom: false) do |f|
+  = f.labeled_input_field :short_name
+  = f.labeled_i18n_enum_field :kind, CourseCompensationCategory.kind_labels
+  = f.labeled_input_fields :description, :name_leader, :name_assistant_leader

--- a/app/views/course_compensation_categories/_form.html.haml
+++ b/app/views/course_compensation_categories/_form.html.haml
@@ -1,0 +1,4 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club SAC. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito

--- a/app/views/course_compensation_categories/_list.html.haml
+++ b/app/views/course_compensation_categories/_list.html.haml
@@ -1,0 +1,6 @@
+-#  Copyright (c) 2024, Schweizer Alpen-Club SAC. This file is part of
+-#  hitobito and licensed under the Affero General Public License version 3
+-#  or later. See the COPYING file at the top-level directory or at
+-#  https://github.com/hitobito/hitobito
+
+= crud_table :text

--- a/app/views/course_compensation_categories/_list.html.haml
+++ b/app/views/course_compensation_categories/_list.html.haml
@@ -3,4 +3,4 @@
 -#  or later. See the COPYING file at the top-level directory or at
 -#  https://github.com/hitobito/hitobito
 
-= crud_table :text
+= crud_table :short_name, :kind, :description, :name_leader, :name_assistant_leader

--- a/app/views/shared/_admin_nav_main_sac_cas.html.haml
+++ b/app/views/shared/_admin_nav_main_sac_cas.html.haml
@@ -1,4 +1,6 @@
 - if can?(:index, Event::Level)
   = nav Event::Level.model_name.human(count: 2), event_levels_path, %w(event_levels)
 - if can?(:index, TerminationReason)
-  = nav TerminationReason.model_name.human(count: 2), termination_reasons_path, %w(termination_reasons) 
+  = nav TerminationReason.model_name.human(count: 2), termination_reasons_path, %w(termination_reasons)
+- if can?(:index, CourseCompensationCategory)
+  = nav CourseCompensationCategory.model_name.human(count: 2), course_compensation_categories_path, %w(course_compensation_categories)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
     end
 
     resources :termination_reasons, except: [:show]
+    resources :course_compensation_categories, except: [:show]
 
     resources :cost_centers
     resources :cost_units

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -127,7 +127,7 @@ module HitobitoSacCas
       Sheet::Person.prepend SacCas::Sheet::Person
 
       admin_item = NavigationHelper::MAIN.find { |item| item[:label] == :admin }
-      admin_item[:active_for] += %w[cost_centers cost_units termination_reasons]
+      admin_item[:active_for] += %w[cost_centers cost_units termination_reasons course_compensation_categories]
 
       ## Controllers
       EventsController.prepend SacCas::EventsController

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -78,6 +78,7 @@ module HitobitoSacCas
       Ability.store.register ExternalTrainingAbility
       Ability.store.register SacMembershipConfigAbility
       Ability.store.register SacSectionMembershipConfigAbility
+      Ability.store.register CourseCompensationCategoryAbility
       Ability.store.register TerminationReasonAbility
       Ability.store.register Memberships::JoinZusatzsektionAbility
       Ability.store.register Memberships::LeaveZusatzsektionAbility

--- a/spec/abilities/course_compensation_category_ability_spec.rb
+++ b/spec/abilities/course_compensation_category_ability_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+require "spec_helper"
+
+describe CourseCompensationCategoryAbility do
+  let(:entry) { Fabricate(:course_compensation_category) }
+  let(:ability) { Ability.new(role.person.reload) }
+
+  context "with admin permission" do
+    let(:role) { roles(:admin) }
+
+    it "may index CourseCompensationCategory records" do
+      expect(ability).to be_able_to(:index, CourseCompensationCategory)
+    end
+
+    it "may manage CourseCompensationCategory records" do
+      expect(ability).to be_able_to(:manage, entry)
+    end
+  end
+
+  context "without admin permission" do
+    let(:role) { roles(:tourenchef_bluemlisalp_ortsgruppe_ausserberg) }
+
+    it "may not index CourseCompensationCategory records" do
+      expect(ability).not_to be_able_to(:index, CourseCompensationCategory)
+    end
+
+    it "may not show CourseCompensationCategory records" do
+      expect(ability).not_to be_able_to(:show, entry)
+    end
+
+    %w[create update destroy].each do |action|
+      it "may not #{action} CourseCompensationCategory records" do
+        expect(ability).not_to be_able_to(action.to_sym, entry)
+      end
+    end
+  end
+end

--- a/spec/controllers/course_compensation_categories_controller_spec.rb
+++ b/spec/controllers/course_compensation_categories_controller_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito
+
+require "spec_helper"
+
+describe CourseCompensationCategoriesController do
+  before { sign_in(person) }
+
+  let(:entry) { Fabricate(:course_compensation_category) }
+
+  describe "with necessary permissions" do
+    let(:person) { people(:admin) }
+
+    context "POST #create" do
+      it "creates entry" do
+        expect do
+          post :create, params: {course_compensation_category: {short_name: "foo"}}
+        end.to change { CourseCompensationCategory.count }.by(1)
+      end
+    end
+
+    context "PATCH #update" do
+      it "updates entry" do
+        expect do
+          patch :update, params: {id: entry.id, course_compensation_category: {short_name: "foo"}}
+        end.to change { entry.reload.short_name }.to("foo")
+      end
+    end
+
+    context "DELETE #destroy" do
+      it "deletes entry" do
+        entry.save!
+        expect do
+          delete :destroy, params: {id: entry.id}
+        end.to change { CourseCompensationCategory.count }.by(-1)
+      end
+    end
+  end
+
+  describe "without admin permissions" do
+    let(:person) { people(:mitglied) }
+
+    context "POST #create" do
+      it "creates entry" do
+        expect do
+          post :create, params: {course_compensation_category: {short_name: "foo"}}
+        end.to raise_error CanCan::AccessDenied
+      end
+    end
+
+    context "PATCH #update" do
+      it "updates entry" do
+        expect do
+          patch :update, params: {id: entry.id, course_compensation_category: {short_name: "foo"}}
+        end.to raise_error CanCan::AccessDenied
+      end
+    end
+
+    context "DELETE #destroy" do
+      it "deletes entry" do
+        expect do
+          delete :destroy, params: {id: entry.id}
+        end.to raise_error CanCan::AccessDenied
+      end
+    end
+
+    context "GET #index" do
+      it "does not list entries" do
+        expect do
+          get :index
+        end.to raise_error CanCan::AccessDenied
+      end
+    end
+
+    context "GET #show" do
+      it "does not show entry" do
+        expect do
+          get :show, params: {id: entry.id}
+        end.to raise_error ActionController::UrlGenerationError
+      end
+    end
+  end
+end

--- a/spec/fixtures/event/levels.yml
+++ b/spec/fixtures/event/levels.yml
@@ -7,12 +7,15 @@
 #
 # Table name: event_levels
 #
-#  id         :bigint           not null, primary key
-#  code       :integer          not null
-#  deleted_at :datetime
-#  difficulty :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :bigint           not null, primary key
+#  code        :integer          not null
+#  deleted_at  :datetime
+#  description :text(65535)
+#  difficulty  :integer          not null
+#  label       :string(255)      not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 
 ---
 ek:

--- a/spec/fixtures/sac_membership_configs.yml
+++ b/spec/fixtures/sac_membership_configs.yml
@@ -8,13 +8,18 @@
 # Table name: sac_membership_configs
 #
 #  id                                             :bigint           not null, primary key
-#  valid_from                                     :integer          not null
-#  sac_fee_adult                                  :decimal(5, 2)    not null
-#  sac_fee_family                                 :decimal(5, 2)    not null
-#  sac_fee_youth                                  :decimal(5, 2)    not null
+#  balancing_payment_article_number               :string(255)      not null
+#  course_fee_article_number                      :string(255)      not null
+#  discount_date_1                                :string(255)
+#  discount_date_2                                :string(255)
+#  discount_date_3                                :string(255)
+#  discount_percent_1                             :integer
+#  discount_percent_2                             :integer
+#  discount_percent_3                             :integer
 #  entry_fee_adult                                :decimal(5, 2)    not null
 #  entry_fee_family                               :decimal(5, 2)    not null
 #  entry_fee_youth                                :decimal(5, 2)    not null
+#  hut_solidarity_fee_article_number              :string(255)      not null
 #  hut_solidarity_fee_with_hut_adult              :decimal(5, 2)    not null
 #  hut_solidarity_fee_with_hut_family             :decimal(5, 2)    not null
 #  hut_solidarity_fee_with_hut_youth              :decimal(5, 2)    not null
@@ -22,26 +27,28 @@
 #  hut_solidarity_fee_without_hut_family          :decimal(5, 2)    not null
 #  hut_solidarity_fee_without_hut_youth           :decimal(5, 2)    not null
 #  magazine_fee_adult                             :decimal(5, 2)    not null
+#  magazine_fee_article_number                    :string(255)      not null
 #  magazine_fee_family                            :decimal(5, 2)    not null
 #  magazine_fee_youth                             :decimal(5, 2)    not null
-#  service_fee                                    :decimal(5, 2)    not null
 #  magazine_postage_abroad                        :decimal(5, 2)    not null
+#  magazine_postage_abroad_article_number         :string(255)      not null
 #  reduction_amount                               :decimal(5, 2)    not null
 #  reduction_required_membership_years            :integer
-#  discount_date_1                                :string(255)
-#  discount_percent_1                             :integer
-#  discount_date_2                                :string(255)
-#  discount_percent_2                             :integer
-#  discount_date_3                                :string(255)
-#  discount_percent_3                             :integer
-#  sac_fee_article_number                         :string(255)      not null
 #  sac_entry_fee_article_number                   :string(255)      not null
-#  hut_solidarity_fee_article_number              :string(255)      not null
-#  magazine_fee_article_number                    :string(255)      not null
+#  sac_fee_adult                                  :decimal(5, 2)    not null
+#  sac_fee_article_number                         :string(255)      not null
+#  sac_fee_family                                 :decimal(5, 2)    not null
+#  sac_fee_youth                                  :decimal(5, 2)    not null
 #  section_bulletin_postage_abroad_article_number :string(255)      not null
+#  section_entry_fee_article_number               :string(255)      not null
+#  section_fee_article_number                     :string(255)      not null
+#  service_fee                                    :decimal(5, 2)    not null
 #  service_fee_article_number                     :string(255)      not null
-#  balancing_payment_article_number               :string(255)      not null
-#  course_fee_article_number                      :string(255)      not null
+#  valid_from                                     :integer          not null
+#
+# Indexes
+#
+#  index_sac_membership_configs_on_valid_from  (valid_from) UNIQUE
 #
 
 '2024':

--- a/spec/fixtures/sac_section_membership_configs.yml
+++ b/spec/fixtures/sac_section_membership_configs.yml
@@ -7,23 +7,28 @@
 #
 # Table name: sac_section_membership_configs
 #
-#  id                                              :bigint           not null, primary key
-#  valid_from                                      :integer          not null
-#  group_id                                        :bigint
+#  id                                          :bigint           not null, primary key
+#  bulletin_postage_abroad                     :decimal(5, 2)    not null
+#  reduction_amount                            :decimal(5, 2)    not null
+#  reduction_required_age                      :integer
+#  reduction_required_membership_years         :integer
+#  sac_fee_exemption_for_benefited_members     :boolean          default(FALSE), not null
+#  sac_fee_exemption_for_honorary_members      :boolean          default(FALSE), not null
+#  section_entry_fee_adult                     :decimal(5, 2)    not null
+#  section_entry_fee_family                    :decimal(5, 2)    not null
+#  section_entry_fee_youth                     :decimal(5, 2)    not null
 #  section_fee_adult                           :decimal(5, 2)    not null
+#  section_fee_exemption_for_benefited_members :boolean          default(FALSE), not null
+#  section_fee_exemption_for_honorary_members  :boolean          default(FALSE), not null
 #  section_fee_family                          :decimal(5, 2)    not null
 #  section_fee_youth                           :decimal(5, 2)    not null
-#  section_entry_fee_adult                                 :decimal(5, 2)    not null
-#  section_entry_fee_family                                :decimal(5, 2)    not null
-#  section_entry_fee_youth                                 :decimal(5, 2)    not null
-#  bulletin_postage_abroad                         :decimal(5, 2)    not null
-#  sac_fee_exemption_for_honorary_members          :boolean          default(FALSE), not null
-#  section_fee_exemption_for_honorary_members  :boolean          default(FALSE), not null
-#  sac_fee_exemption_for_benefited_members         :boolean          default(FALSE), not null
-#  section_fee_exemption_for_benefited_members :boolean          default(FALSE), not null
-#  reduction_amount                                :decimal(5, 2)    not null
-#  reduction_required_membership_years             :integer
-#  reduction_required_age                          :integer
+#  valid_from                                  :integer          not null
+#  group_id                                    :bigint           not null
+#
+# Indexes
+#
+#  index_sac_section_membership_configs_on_group_id                 (group_id)
+#  index_sac_section_membership_configs_on_group_id_and_valid_from  (group_id,valid_from) UNIQUE
 #
 
 bluemlisalp_2024:


### PR DESCRIPTION
Die Seeds zu dem Thema sind im PR #740.

https://github.com/user-attachments/assets/1cb60c08-f7f5-4ac3-9c72-356564365774

In diesem PR habe ich mir erlaubt die von `annotate` generierten Schema Information vom SAC Wagon zu aktualisieren.