### PR TITLE
PEOPLE: Bemerkungsfelder Berechtigungen fix

### DIFF
--- a/app/abilities/sac_cas/person_ability.rb
+++ b/app/abilities/sac_cas/person_ability.rb
@@ -22,7 +22,7 @@ module SacCas::PersonAbility
         .if_person_is_adult_and_all_household_members_writable
       permission(:any).may(:show_remarks).if_backoffice_or_functionary
       permission(:any).may(:manage_national_office_remark).if_backoffice
-      permission(:any).may(:manage_section_remarks).if_section_functionary
+      permission(:any).may(:manage_section_remarks).if_backoffice_or_functionary
     end
 
     def if_backoffice_or_functionary

--- a/spec/abilities/sac_cas/person_ability_spec.rb
+++ b/spec/abilities/sac_cas/person_ability_spec.rb
@@ -128,7 +128,7 @@ describe PersonAbility do
       it "is permitted to manage geschaeftsstelle remark but not section" do
         expect(ability).to be_able_to(:show_remarks, person)
         expect(ability).to be_able_to(:manage_national_office_remark, person)
-        expect(ability).not_to be_able_to(:manage_section_remarks, person)
+        expect(ability).to be_able_to(:manage_section_remarks, person)
       end
     end
 

--- a/spec/api/people/show_spec.rb
+++ b/spec/api/people/show_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe "people#show", type: :request do
     end
 
     context "as employee" do
-      it "can read national office remark but not section remarks" do
+      it "can read all remarks" do
         sign_in(person)
         make_request
         expect(d.sac_remark_national_office).to eq("Remark")
-        expect(d.sac_remark_section_1).to be_nil
+        expect(d.sac_remark_section_1).to eq("Remark")
       end
     end
 

--- a/spec/controllers/person/sac_remarks_controller_spec.rb
+++ b/spec/controllers/person/sac_remarks_controller_spec.rb
@@ -79,10 +79,9 @@ describe Person::SacRemarksController do
         expect(response).to have_http_status(:success)
       end
 
-      it "cannot edit section remarks" do
-        expect do
-          get :edit, params: {group_id: group_id, person_id: person.id, id: :sac_remark_section_1}
-        end.to raise_error(CanCan::AccessDenied)
+      it "can edit section remarks" do
+        get :edit, params: {group_id: group_id, person_id: person.id, id: :sac_remark_section_1}
+        expect(response).to have_http_status(:success)
       end
     end
 
@@ -139,11 +138,11 @@ describe Person::SacRemarksController do
         end.to change { person.reload.sac_remark_national_office }.from(nil).to("example")
       end
 
-      it "cannot manage section remarks" do
+      it "can manage section remarks" do
         expect do
           put :update, params: {group_id: group_id, person_id: person.id, id: :sac_remark_section_1,
                                 person: {sac_remark_section_1: "example"}}
-        end.to raise_error(CanCan::AccessDenied)
+        end.to change { person.reload.sac_remark_section_1 }.from(nil).to("example")
       end
     end
 

--- a/spec/domain/table_displays/resolver_spec.rb
+++ b/spec/domain/table_displays/resolver_spec.rb
@@ -191,7 +191,7 @@ describe TableDisplays::Resolver, type: :helper do
       expect(described_class.new(view, person, :sac_remark_section_1).exclude_attr?).to be_truthy
       person.roles.build(type: Group::Geschaeftsstelle::Admin.sti_name)
       expect(view).to receive(:parent).and_return(person.roles.last)
-      expect(described_class.new(view, person, :sac_remark_section_1).exclude_attr?).to be_truthy
+      expect(described_class.new(view, person, :sac_remark_section_1).exclude_attr?).to be_falsy
       person.roles.build(type: ::Group::SektionsFunktionaere::Praesidium.sti_name)
       expect(view).to receive(:parent).and_return(person.roles.last)
       expect(described_class.new(view, person, :sac_remark_section_1).exclude_attr?).to be_falsy


### PR DESCRIPTION
Fixes #511
Refs https://github.com/hitobito/hitobito_sac_cas/issues/511#issuecomment-2242477708

Nun kann die Geschäftsstelle alle Remarks sehen