### PR TITLE
EVENTS: E-Mail Reminder Kursleitung

### DIFF
--- a/app/jobs/event/leader_reminder_job.rb
+++ b/app/jobs/event/leader_reminder_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+class Event::LeaderReminderJob < RecurringJob
+  run_every 1.day
+
+  private
+
+  def perform_internal
+    Event::Course.joins(:dates)
+      .where(event_dates: {start_at: 8.weeks.from_now.all_day})
+      .where.not(contact: nil)
+      .uniq.each do |course|
+      Event::LeaderReminderMailer.reminder(course).deliver_now
+    end
+  end
+
+  def next_run
+    interval.from_now.midnight + 5.minutes
+  end
+end

--- a/app/mailers/event/leader_reminder_mailer.rb
+++ b/app/mailers/event/leader_reminder_mailer.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class Event::LeaderReminderMailer < ApplicationMailer
+  include Rails.application.routes.url_helpers
+
+  REMINDER = "event_leader_reminder"
+
+  def reminder(course)
+    return if course.contact.nil?
+
+    @course = course
+    values = values_for_placeholders(REMINDER)
+    headers = {bcc: course.groups.first.course_admin_email}
+    locales = course.language.split("_")
+
+    custom_content_mail(course.contact, REMINDER, values, headers, locales)
+  end
+
+  private
+
+  def placeholder_recipient_name
+    @course.contact.greeting_name
+  end
+
+  def placeholder_event_name
+    @course.name
+  end
+
+  def placeholder_event_number
+    @course.number
+  end
+
+  def placeholder_six_weeks_before_start
+    l((@course.dates.order(:start_at).first.start_at - 6.weeks).to_date)
+  end
+
+  def placeholder_event_link
+    link_to group_event_url(group_id: @course.group_ids.first, id: @course.id)
+  end
+
+  # https://github.com/hitobito/hitobito/blob/master/app/mailers/event/participation_mailer.rb#L112
+  def placeholder_event_details
+    info = []
+    info << labeled(:dates) { @course.dates.map(&:to_s).join("<br>") }
+    info << labeled(:motto)
+    info << labeled(:cost)
+    info << labeled(:description) { @course.description.gsub("\n", "<br>") }
+    info << labeled(:location) { @course.location.gsub("\n", "<br>") }
+    info << labeled(:contact) { "#{@course.contact}<br>#{@course.contact.email}" }
+    info.compact.join("<br><br>")
+  end
+
+  def labeled(key)
+    value = @course.send(key).presence
+    if value
+      label = @course.class.human_attribute_name(key)
+      formatted = block_given? ? yield : value
+      "#{label}:<br>#{formatted}"
+    end
+  end
+end

--- a/app/mailers/event/leader_reminder_mailer.rb
+++ b/app/mailers/event/leader_reminder_mailer.rb
@@ -11,14 +11,11 @@ class Event::LeaderReminderMailer < ApplicationMailer
   REMINDER = "event_leader_reminder"
 
   def reminder(course)
-    return if course.contact.nil?
-
     @course = course
-    values = values_for_placeholders(REMINDER)
     headers = {bcc: course.groups.first.course_admin_email}
     locales = course.language.split("_")
 
-    custom_content_mail(course.contact, REMINDER, values, headers, locales)
+    compose(course.contact, REMINDER, headers, locales)
   end
 
   private

--- a/app/mailers/sac_cas/application_mailer.rb
+++ b/app/mailers/sac_cas/application_mailer.rb
@@ -43,7 +43,7 @@ module SacCas::ApplicationMailer
   end
 
   def join_contents(contents)
-    contents = contents.join("<br><br>--------------------<br><br>").gsub("\n", "<br>")
+    contents = contents.join("<br><br>--------------------<br><br>")
     "<div class=\"trix-content\">#{contents}</div>"
   end
 end

--- a/app/mailers/sac_cas/application_mailer.rb
+++ b/app/mailers/sac_cas/application_mailer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module SacCas::ApplicationMailer
+  private
+
+  def compose(recipients, content_key, locales = [])
+    return if recipients.blank?
+
+    values = values_for_placeholders(content_key)
+    custom_content_mail(recipients, content_key, values, {}, locales)
+  end
+
+  def custom_content_mail(recipients, content_key, values, headers = {}, locales = [])
+    original_locale = I18n.locale
+    locales = [I18n.locale] if locales.empty?
+    headers[:to] = use_mailing_emails(recipients)
+
+    contents = locales.map do |locale|
+      content = localized_content_for(locale, content_key)
+      content = localized_content_for(I18n.default_locale, content_key) if content.body.body.nil?
+      headers[:subject] ||= content.subject_with_values(values) if locale == locales.first
+
+      # TODO: make method public in core and remove .send
+      content.send(:replace_placeholders, content.body.to_plain_text, values)
+    end
+
+    I18n.locale = original_locale
+    mail(headers) { |format| format.html { render plain: join_contents(contents) } }
+  end
+
+  def localized_content_for(locale, content_key)
+    I18n.locale = locale
+    CustomContent.get(content_key)
+  end
+
+  def join_contents(contents)
+    contents = contents.join("\n\n--------------------\n\n").gsub("\n", "<br>")
+    "<div class=\"trix-content\">#{contents}</div>"
+  end
+end

--- a/app/mailers/sac_cas/application_mailer.rb
+++ b/app/mailers/sac_cas/application_mailer.rb
@@ -24,7 +24,7 @@ module SacCas::ApplicationMailer
       I18n.with_locale(locale) do
         body, subject = content_subject_and_body(content, values, locale, locales)
 
-        if body.body.nil?
+        if body.blank?
           I18n.with_locale(I18n.default_locale) do
             body, subject = content_subject_and_body(content, values, locale, locales)
           end

--- a/app/mailers/sac_cas/application_mailer.rb
+++ b/app/mailers/sac_cas/application_mailer.rb
@@ -34,12 +34,12 @@ module SacCas::ApplicationMailer
   end
 
   def localized_content_for(locale, content_key)
-    I18n.locale = locale
+    I18n.locale = locale # `with_locale` doesn't work for CustomContent
     CustomContent.get(content_key)
   end
 
   def join_contents(contents)
-    contents = contents.join("\n\n--------------------\n\n").gsub("\n", "<br>")
+    contents = contents.join("<br><br>--------------------<br><br>").gsub("\n", "<br>")
     "<div class=\"trix-content\">#{contents}</div>"
   end
 end

--- a/app/mailers/sac_cas/application_mailer.rb
+++ b/app/mailers/sac_cas/application_mailer.rb
@@ -8,11 +8,11 @@
 module SacCas::ApplicationMailer
   private
 
-  def compose(recipients, content_key, locales = [])
+  def compose(recipients, content_key, headers = {}, locales = [])
     return if recipients.blank?
 
     values = values_for_placeholders(content_key)
-    custom_content_mail(recipients, content_key, values, {}, locales)
+    custom_content_mail(recipients, content_key, values, headers, locales)
   end
 
   def custom_content_mail(recipients, content_key, values, headers = {}, locales = [])

--- a/db/seeds/custom_contents.rb
+++ b/db/seeds/custom_contents.rb
@@ -9,6 +9,8 @@ CustomContent.seed_once(:key,
 { key: Event::ParticipationMailer::CONTENT_REJECTED_PARTICIPATION, # 'event_participation_rejected`
   placeholders_required: 'participant-name',
   placeholders_optional: 'event-name, application-url, event-details' },
+  { key: Event::LeaderReminderMailer::REMINDER,
+    placeholders_required: 'recipient-name, event-details, event-name, event-number, event-link, six-weeks-before-start' },
   { key: Qualifications::ExpirationMailer::REMINDER_TODAY },
   { key: Qualifications::ExpirationMailer::REMINDER_NEXT_YEAR },
   { key: Qualifications::ExpirationMailer::REMINDER_YEAR_AFTER_NEXT_YEAR },
@@ -38,6 +40,22 @@ CustomContent::Translation.seed_once(:custom_content_id, :locale,
   { custom_content_id: participation_rejected_id,
     locale: 'it',
     label: "Evento: E-mail della notifica della rifiuto" },
+  { custom_content_id: CustomContent.get(Event::LeaderReminderMailer::REMINDER).id,
+    locale: 'de',
+    label: 'Kurs: E-Mail Reminder Kursleitung',
+    subject: 'Erinnerung Kursstart',
+    body: "Hallo {recipient-name},<br><br>" \
+          "Der Kurs {event-name} mit Nummer {event-number} finded 6 Wochen nach dem {six-weeks-before-start} statt." \
+          "<br>Siehe {event-link} für mehr Info.<br><br>" \
+          "Kursdetails:<br><br>{event-details}" },
+  { custom_content_id: CustomContent.get(Event::LeaderReminderMailer::REMINDER).id,
+    locale: 'fr',
+    label: 'Kurs: E-Mail Reminder Kursleitung',
+    subject: 'Rappel de début de cours',
+    body: "Bonjour {recipient-name},<br><br>" \
+        "Le cours {event-name} avec le numéro {event-number} aura lieu 6 semaines après le {six-weeks-before-start}." \
+        "<br>Veuillez consulter {event-link} pour plus d'informations.<br><br>" \
+        "Détails du cours:<br><br>{event-details}" },
   { custom_content_id: CustomContent.get(Qualifications::ExpirationMailer::REMINDER_TODAY).id,
     locale: 'de',
     label: 'Qualifikation: Erinnerungsmail morgen',

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -41,6 +41,7 @@ module HitobitoSacCas
       Event::ParticipationBanner.prepend SacCas::Event::ParticipationBanner
       Event::ParticipationContactData.prepend SacCas::Event::ParticipationContactData
       Event::Participatable.prepend SacCas::Event::Participatable
+      ApplicationMailer.prepend SacCas::ApplicationMailer
       Event::ParticipationMailer.prepend SacCas::Event::ParticipationMailer
       FutureRole.prepend SacCas::FutureRole
       Group.include SacCas::Group

--- a/spec/jobs/event/leader_reminder_job_spec.rb
+++ b/spec/jobs/event/leader_reminder_job_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require "spec_helper"
+
+describe Event::LeaderReminderJob do
+  subject(:job) { described_class.new }
+
+  context "rescheduling" do
+    it "reschedules for tomorrow at 5 minutes past midnight" do
+      job.perform
+      next_job = Delayed::Job.find_by("handler like '%LeaderReminderJob%'")
+      expect(next_job.run_at).to eq Time.zone.tomorrow + 5.minutes
+    end
+  end
+
+  context "with contact person" do
+    let!(:course) do
+      Fabricate(:sac_open_course, contact_id: people(:admin).id, dates: [
+        Fabricate(:event_date, start_at: 8.weeks.from_now)
+      ])
+    end
+
+    context "with one course language" do
+      it "mails a reminder" do
+        expect { job.perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+    end
+
+    context "with multiple course languages" do
+      before { course.update!(language: "de_fr") }
+
+      it "mails a reminder in both languages" do
+        expect { job.perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        expect(ActionMailer::Base.deliveries.last.body.to_s).to include("Hallo", "-----", "Bonjour")
+      end
+    end
+
+    context "with course admin email" do
+      before { course.groups.first.update!(course_admin_email: "admin@example.com") }
+
+      it "mails a bcc to the admin" do
+        expect { job.perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        expect(ActionMailer::Base.deliveries.last.bcc).to include("admin@example.com")
+      end
+    end
+  end
+
+  context "without contact person" do
+    let!(:course) do
+      Fabricate(:sac_open_course, dates: [
+        Fabricate(:event_date, start_at: 8.weeks.from_now)
+      ])
+    end
+
+    it "doesnt mail a reminder" do
+      expect { job.perform }.not_to change(ActionMailer::Base.deliveries, :count)
+    end
+  end
+
+  context "course doesnt start in 8 weeks" do
+    subject(:course) do
+      Fabricate(:sac_open_course, contact_id: people(:admin).id, dates: [
+        Fabricate(:event_date, start_at: start_at)
+      ])
+    end
+
+    context "starts in 7 weeks" do
+      let(:start_at) { 7.weeks.from_now }
+
+      it "doesnt mail a reminder" do
+        course
+        expect { job.perform }.not_to change(ActionMailer::Base.deliveries, :count)
+      end
+    end
+
+    context "starts in 9 weeks" do
+      let(:start_at) { 9.weeks.from_now }
+
+      it "doesnt mail a reminder" do
+        course
+        expect { job.perform }.not_to change(ActionMailer::Base.deliveries, :count)
+      end
+    end
+  end
+end

--- a/spec/jobs/event/leader_reminder_job_spec.rb
+++ b/spec/jobs/event/leader_reminder_job_spec.rb
@@ -40,6 +40,15 @@ describe Event::LeaderReminderJob do
       end
     end
 
+    context "with course languages that doesnt have customcontent" do
+      before { course.update!(language: "it") }
+
+      it "mails a reminder in the default language" do
+        expect { job.perform }.to change(ActionMailer::Base.deliveries, :count).by(1)
+        expect(ActionMailer::Base.deliveries.last.body.to_s).to include("Hallo")
+      end
+    end
+
     context "with course admin email" do
       before { course.groups.first.update!(course_admin_email: "admin@example.com") }
 


### PR DESCRIPTION
Fixes #629

zum testen auf localhost:
```ruby
# hit rails c
Event::Course.first.dates.first.update! start_at: 8.weeks.from_now.to_date, finish_at: 9.weeks.from_now.to_date
Event::Course.first.groups.first.update! course_admin_email: 'admin@example.com'
Event::LeaderReminderJob.new.perform
```
dann im mailcatcher schauen. sprache bearbeitbar auf http://localhost:3000/de/groups/1/events/1/edit