### PR TITLE
EVENTS: E-Mail Anmeldebestätigung

### DIFF
--- a/app/domain/sac_cas/event/participant_assigner.rb
+++ b/app/domain/sac_cas/event/participant_assigner.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module SacCas::Event::ParticipantAssigner
+  def send_confirmation
+    nil
+  end
+end

--- a/app/jobs/event/application_confirmation_job.rb
+++ b/app/jobs/event/application_confirmation_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class Event::ApplicationConfirmationJob < BaseJob
+  self.parameters = %i[content_key participation_id]
+
+  def initialize(participation, content_key)
+    super()
+    @content_key = content_key
+    @participation_id = participation.id
+  end
+
+  def perform
+    return unless participation # may have been deleted again
+
+    Event::ApplicationConfirmationMailer.confirmation(participation, @content_key).deliver_now
+  end
+
+  private
+
+  def participation
+    @participation ||= Event::Participation.find_by(id: @participation_id)
+  end
+end

--- a/app/mailers/concerns/event_mailer.rb
+++ b/app/mailers/concerns/event_mailer.rb
@@ -19,6 +19,10 @@ module EventMailer
     l(@course.application_opening_at)
   end
 
+  def placeholder_application_closing_at
+    l(@course.application_closing_at)
+  end
+
   def placeholder_six_weeks_before_start
     l((@course.dates.order(:start_at).first.start_at - 6.weeks).to_date)
   end

--- a/app/mailers/event/application_confirmation_mailer.rb
+++ b/app/mailers/event/application_confirmation_mailer.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class Event::ApplicationConfirmationMailer < ApplicationMailer
+  include EventMailer
+
+  APPLIED = "course_application_confirmation_applied"
+  UNCONFIRMED = "course_application_confirmation_unconfirmed"
+  ASSIGNED = "course_application_confirmation_assigned"
+
+  def confirmation(participation, content_key)
+    @participation = participation
+    @course = participation.event
+    headers = {bcc: @course.groups.first.course_admin_email}
+    locales = @course.language.split("_")
+
+    compose(@participation.person, content_key, headers, locales)
+  end
+
+  private
+
+  def placeholder_recipient_name
+    @participation.person.greeting_name
+  end
+
+  def placeholder_person_url
+    link_to(person_url(@participation.person))
+  end
+
+  def placeholder_application_url
+    link_to(group_event_participation_url(
+      group_id: @course.groups.first.id,
+      event_id: @course.id,
+      id: @participation.id
+    ))
+  end
+
+  def placeholder_missing_information
+    missing_questions = Event::Question.admin.joins(:answers)
+      .where(answers: {participation: @participation, answer: [nil, "", "nein", "non", "no"]})
+      .pluck(:question).map { |question| ["<li>", question].join }.join
+
+    return "" if missing_questions.blank?
+
+    "#{t("event.participations.missing_information")}<br><ul>#{missing_questions}</ul>"
+  end
+end

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -974,6 +974,7 @@ de:
           überschrieben.
 
     participations:
+      missing_information: Für die Teilnahme an diesem Kurs sind die folgenden Nachweise zu erbringen. Bitte reiche diese noch ein, falls du dies nicht schon getan hast.
       answers_step:
         total_duration_days_help: "Geplante Kursdauer: %{total_days} Tage"
       edit:

--- a/db/seeds/custom_contents.rb
+++ b/db/seeds/custom_contents.rb
@@ -95,27 +95,33 @@ CustomContent::Translation.seed_once(:custom_content_id, :locale,
    label: "Kurs: E-Mail Unbestätigte Warteliste",
    subject: "Auf Warteliste gesetzt",
    body: "Hallo {recipient-name},<br><br>" \
-     "Du wurdest für den Kurs {event-link} auf die unbestätigte Warteliste gesetzt. " \
-     "Anmeldeschluss ist der {application-closing-at}. " \
-     "Siehe {application-url} und {person-url}<br/><br/>" \
+     "Du wurdest für den Kurs {event-name} (Nummer: {event-number}) auf die unbestätigte Warteliste gesetzt. " \
+     "Anmeldeschluss ist der {application-closing-at}.<br><br>" \
+     "Anmeldung: {application-url}<br>" \
+     "Person: {person-url}<br>" \
+     "Event-Link: {event-link}<br>" \
      "Kursdetails:<br><br>{event-details}<br><br>{missing-information}"},
   {custom_content_id: CustomContent.get(Event::ApplicationConfirmationMailer::UNCONFIRMED).id,
    locale: "de",
    label: "Kurs: E-Mail Unbestätigte Kursanmeldung",
    subject: "Unbestätigte Kursanmeldung",
    body: "Hallo {recipient-name},<br><br>" \
-     "Du wurdest für den Kurs {event-link} auf die unbestätigte Kursanmeldung gesetzt. " \
-     "Anmeldeschluss ist der {application-closing-at}. " \
-     "Siehe {application-url} und {person-url}<br/><br/>" \
+     "Du wurdest für den Kurs {event-name} (Nummer: {event-number}) auf die unbestätigte Kursanmeldung gesetzt. " \
+     "Anmeldeschluss ist der {application-closing-at}.<br><br>" \
+     "Anmeldung: {application-url}<br>" \
+     "Person: {person-url}<br>" \
+     "Event-Link: {event-link}<br>" \
      "Kursdetails:<br><br>{event-details}<br><br>{missing-information}"},
   {custom_content_id: CustomContent.get(Event::ApplicationConfirmationMailer::ASSIGNED).id,
    locale: "de",
    label: "Kurs: E-Mail Bestätigte Kursanmeldung",
    subject: "Kursanmeldung bestätigt",
    body: "Hallo {recipient-name},<br><br>" \
-     "Deine Anmeldung für den Kurs {event-link} wurde bestätigt. " \
-     "Anmeldeschluss ist der {application-closing-at}. " \
-     "Siehe {application-url} und {person-url}<br/><br/>" \
+     "Deine Anmeldung für den Kurs {event-name} (Nummer: {event-number}) wurde bestätigt. " \
+     "Anmeldeschluss ist der {application-closing-at}.<br><br>" \
+     "Anmeldung: {application-url}<br>" \
+     "Person: {person-url}<br>" \
+     "Event-Link: {event-link}<br>" \
      "Kursdetails:<br><br>{event-details}<br><br>{missing-information}"},
   {custom_content_id: leader_reminder_next_week_id,
    locale: "de",

--- a/db/seeds/custom_contents.rb
+++ b/db/seeds/custom_contents.rb
@@ -12,6 +12,15 @@ CustomContent.seed_once(:key,
   {key: Event::ParticipationMailer::CONTENT_SUMMON,
    placeholders_required: "event-name",
    placeholders_optional: "recipient-name, event-details, event-number, application-url, person-url, event-link, book-discount-code"},
+  {key: Event::ApplicationConfirmationMailer::APPLIED,
+   placeholders_required: "event-name",
+   placeholders_optional: "recipient-name, event-details, event-number, event-link, application-url, application-closing-at, person-url, missing-information"},
+  {key: Event::ApplicationConfirmationMailer::UNCONFIRMED,
+   placeholders_required: "event-name",
+   placeholders_optional: "recipient-name, event-details, event-number, event-link, application-url, application-closing-at, person-url, missing-information"},
+  {key: Event::ApplicationConfirmationMailer::ASSIGNED,
+   placeholders_required: "event-name",
+   placeholders_optional: "recipient-name, event-details, event-number, event-link, application-url, application-closing-at, person-url, missing-information"},
   {key: Event::LeaderReminderMailer::REMINDER_NEXT_WEEK,
    placeholders_required: "event-name",
    placeholders_optional: "recipient-name, event-details, event-number, event-link"},
@@ -81,6 +90,33 @@ CustomContent::Translation.seed_once(:custom_content_id, :locale,
      "Personne: {person-url}<br>" \
      "Lien de l'événement: {event-link}<br>" \
      "Code de réduction pour le livre: {book-discount-code}"},
+  {custom_content_id: CustomContent.get(Event::ApplicationConfirmationMailer::APPLIED).id,
+   locale: "de",
+   label: "Kurs: E-Mail Unbestätigte Warteliste",
+   subject: "Auf Warteliste gesetzt",
+   body: "Hallo {recipient-name},<br><br>" \
+     "Du wurdest für den Kurs {event-link} auf die unbestätigte Warteliste gesetzt. " \
+     "Anmeldeschluss ist der {application-closing-at}. " \
+     "Siehe {application-url} und {person-url}<br/><br/>" \
+     "Kursdetails:<br><br>{event-details}<br><br>{missing-information}"},
+  {custom_content_id: CustomContent.get(Event::ApplicationConfirmationMailer::UNCONFIRMED).id,
+   locale: "de",
+   label: "Kurs: E-Mail Unbestätigte Kursanmeldung",
+   subject: "Unbestätigte Kursanmeldung",
+   body: "Hallo {recipient-name},<br><br>" \
+     "Du wurdest für den Kurs {event-link} auf die unbestätigte Kursanmeldung gesetzt. " \
+     "Anmeldeschluss ist der {application-closing-at}. " \
+     "Siehe {application-url} und {person-url}<br/><br/>" \
+     "Kursdetails:<br><br>{event-details}<br><br>{missing-information}"},
+  {custom_content_id: CustomContent.get(Event::ApplicationConfirmationMailer::ASSIGNED).id,
+   locale: "de",
+   label: "Kurs: E-Mail Bestätigte Kursanmeldung",
+   subject: "Kursanmeldung bestätigt",
+   body: "Hallo {recipient-name},<br><br>" \
+     "Deine Anmeldung für den Kurs {event-link} wurde bestätigt. " \
+     "Anmeldeschluss ist der {application-closing-at}. " \
+     "Siehe {application-url} und {person-url}<br/><br/>" \
+     "Kursdetails:<br><br>{event-details}<br><br>{missing-information}"},
   {custom_content_id: leader_reminder_next_week_id,
    locale: "de",
    label: "Kurs: E-Mail Kursvorbereitungen abschliessen",

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -108,6 +108,7 @@ module HitobitoSacCas
       )
       SearchStrategies::Sql::SEARCH_FIELDS["Person"][:attrs] << "people.id"
 
+      Event::ParticipantAssigner.prepend SacCas::Event::ParticipantAssigner
       Event::TrainingDays::CoursesLoader.prepend SacCas::Event::TrainingDays::CoursesLoader
       SearchStrategies::Sql.prepend SacCas::SearchStrategies::Sql
       SearchStrategies::Sphinx.prepend SacCas::SearchStrategies::Sphinx


### PR DESCRIPTION
Fixes #625

**Auf localhost testen**
Kursanmeldung bestätigt: [hier](http://localhost:3000/de/groups/1/events/1/participations/new?event_role[type]=Event%3A%3ACourse%3A%3ARole%3A%3AParticipant&for_someone_else=true) einen teilnehmer hinzufügen
Unbestätigte Kursanmeldung: [hier](http://localhost:3000/de/groups/1/events/1/register) selbst registrieren