### PR TITLE
GROUPS: Anpassungen Gruppenstruktur Toplayer > Abonnenten

### DIFF
--- a/app/domain/sac_cas/oidc_claim_setup.rb
+++ b/app/domain/sac_cas/oidc_claim_setup.rb
@@ -27,6 +27,7 @@ module SacCas::OidcClaimSetup
     tourenportal_author: [Group::AboTourenPortal::Autor],
     tourenportal_community: [Group::AboTourenPortal::Community],
     tourenportal_administrator: [Group::AboTourenPortal::Admin],
+    tourenportal_gratisabonnent: [Group::AboTourenPortal::Gratisabonnent],
     magazin_subscriber: Group::AboMagazin.roles,
     section_tour_functionary: [
       Group::SektionsTourenUndKurse::JsCoach,

--- a/app/models/group/abo_magazin.rb
+++ b/app/models/group/abo_magazin.rb
@@ -23,5 +23,5 @@ class Group::AboMagazin < ::Group
     self.basic_permissions_only = true
   end
 
-  roles Abonnent, Neuanmeldung, Autor, Andere
+  roles Abonnent, Neuanmeldung, Andere
 end

--- a/app/models/group/abo_magazine.rb
+++ b/app/models/group/abo_magazine.rb
@@ -5,15 +5,11 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas.
 
-class Group::AboMagazin < ::Group
-  ### ROLES
-  class Abonnent < ::Role
-    self.permissions = []
-    self.basic_permissions_only = true
-    self.terminatable = true
-  end
+class Group::AboMagazine < ::Group
+  self.static_name = true
 
-  class Neuanmeldung < ::Role
+  ### ROLES
+  class Autor < ::Role
     self.permissions = []
     self.basic_permissions_only = true
   end
@@ -23,5 +19,10 @@ class Group::AboMagazin < ::Group
     self.basic_permissions_only = true
   end
 
-  roles Abonnent, Neuanmeldung, Autor, Andere
+  class Uebersetzer < ::Role
+    self.permissions = []
+    self.basic_permissions_only = true
+  end
+
+  children Group::AboMagazin
 end

--- a/app/models/group/abo_magazine.rb
+++ b/app/models/group/abo_magazine.rb
@@ -25,4 +25,5 @@ class Group::AboMagazine < ::Group
   end
 
   children Group::AboMagazin
+  roles Autor, Andere, Uebersetzer
 end

--- a/app/models/group/abo_touren_portal.rb
+++ b/app/models/group/abo_touren_portal.rb
@@ -40,5 +40,10 @@ class Group::AboTourenPortal < ::Group
     self.basic_permissions_only = true
   end
 
+  class Gratisabonnent < ::Role
+    self.permissions = []
+    self.basic_permissions_only = true
+  end
+
   roles Abonnent, Neuanmeldung, Admin, Autor, Community, Andere
 end

--- a/app/models/group/abo_touren_portal.rb
+++ b/app/models/group/abo_touren_portal.rb
@@ -45,5 +45,5 @@ class Group::AboTourenPortal < ::Group
     self.basic_permissions_only = true
   end
 
-  roles Abonnent, Neuanmeldung, Admin, Autor, Community, Andere
+  roles Abonnent, Neuanmeldung, Admin, Autor, Community, Andere, Gratisabonnent
 end

--- a/app/models/group/abos.rb
+++ b/app/models/group/abos.rb
@@ -5,10 +5,10 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas.
 
-class Group::Abonnenten < ::Group
+class Group::Abos < ::Group
   self.static_name = true
 
   children Group::AboTourenPortal,
-    Group::AboMagazin,
+    Group::AboMagazine,
     Group::AboBasicLogin
 end

--- a/app/models/group/sac_cas.rb
+++ b/app/models/group/sac_cas.rb
@@ -15,7 +15,7 @@ class Group::SacCas < Group
     Group::Kommission,
     Group::Sektion,
     Group::ExterneKontakte,
-    Group::Abonnenten,
+    Group::Abos,
     Group::Ehrenmitglieder
 
   mounted_attr :course_admin_email, :string

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -528,6 +528,10 @@ de:
         one: SAC Abos (ohne Newesletter)
         other: SAC Abos (ohne Newesletter)
 
+      group/abo_magazin:
+        one: AboMagazin
+        other: AboMagazin
+
       group/abo_magazine:
         one: SAC-Magazin
         other: SAC-Magazin

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -694,6 +694,9 @@ de:
       group/abo_touren_portal/andere:
         one: Andere
         description: Andere
+      group/abo_touren_portal/gratisabonnent:
+        one: Gratisabonnent
+        description: Gratisabonnent
       group/abo_basic_login/basic_login:
         one: Basis Konto
         description: Basis Konto

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -419,7 +419,7 @@ de:
         total: Total
         issued_at: Rechnungsdatum
         created_at: Erstellt
-        updated_at: Aktualisiert            
+        updated_at: Aktualisiert
         states:
           draft: Entwurf
           open: Offen
@@ -438,7 +438,7 @@ de:
         must_have_mitglied_role: "muss Mitglied sein während der ganzen Gültigkeitsdauer der Zusatzsektion."
         must_have_mitglied_role_in_group: "muss Mitglied in der ausgewählten Gruppe sein."
         must_have_one_family_main_person_in_family: "In einer Familienmitgliedschaft muss ein Rechnungsempfänger definiert sein."
-          
+
       models:
         course_compensation_rate:
           attributes:
@@ -524,17 +524,17 @@ de:
         one: SAC Zentralvorstand
         other: SAC Zentralvorstand
 
-      group/abonnenten:
-        one: Abonnenten
-        other: Abonnenten
+      group/abos:
+        one: SAC Abos (ohne Newesletter)
+        other: SAC Abos (ohne Newesletter)
 
-      group/abo_magazin:
-        one: AboMagazin
-        other: AboMagazin
+      group/abo_magazine:
+        one: SAC-Magazin
+        other: SAC-Magazin
 
       group/abo_touren_portal:
-        one: SAC Tourenportal
-        other: SAC Tourenportal
+        one: SAC-Tourenportal
+        other: SAC-Tourenportal
 
       group/abo_basic_login:
         one: SAC/CAS Login
@@ -658,15 +658,21 @@ de:
       group/externe_kontakte/kontakt:
         one: Kontakt
         description: Kontakt
+      group/abo_magazine/autor:
+        one: Autor*in
+        description: Autor*in
+      group/abo_magazine/andere:
+        one: Andere
+        description: Andere
+      group/abo_magazine/uebersetzer:
+        one: Übersetzer*in
+        description: Übersetzer*in
       group/abo_magazin/abonnent:
         one: Abonnent
         description: Abonnent
       group/abo_magazin/neuanmeldung:
         one: Neuanmeldung
         description: Neuanmeldung
-      group/abo_magazin/autor:
-        one: Autor*in
-        description: Autor*in
       group/abo_magazin/andere:
         one: Andere
         description: Andere
@@ -1102,12 +1108,12 @@ de:
       section_sac_membership: SAC Mitgliedschaft
       qr_code_hint: Scannen um Mitgliedschaft zu verifizieren
       download_pdf: Mitgliederausweis herunterladen
-      
+
     external_invoices:
       table:
         cancel_invoice: Stornieren
         cancel_invoice_confirmation: "Wollen Sie diese Rechnung wirklich stornieren? Diese Aktion kann nicht rückgängig gemacht werden."
-      cancel: 
+      cancel:
         flash: "Die Rechnung %{invoice} (Auftrags-Nr. %{abacus_sales_order_key}) wird storniert"
       list:
         create_membership_invoice: Mitgliedschaftsrechnung erstellen

--- a/config/locales/wagon.en.yml
+++ b/config/locales/wagon.en.yml
@@ -681,6 +681,9 @@ en:
       group/abo_touren_portal/andere:
         one: ""
         description: ""
+      group/abo_touren_portal/gratisabonnent:
+        one: ""
+        description: ""
       group/abo_basic_login/basic_login:
         one: ""
         description: ""

--- a/config/locales/wagon.en.yml
+++ b/config/locales/wagon.en.yml
@@ -515,6 +515,10 @@ en:
         one: ''
         other: ''
 
+      group/abo_magazin:
+        one: ''
+        other: ''
+
       group/abo_magazine:
         one: ''
         other: ''

--- a/config/locales/wagon.en.yml
+++ b/config/locales/wagon.en.yml
@@ -410,7 +410,7 @@ en:
         total: ""
         issued_at: ""
         created_at: ""
-        updated_at: ""            
+        updated_at: ""
         states:
           draft: ""
           open: ""
@@ -429,7 +429,7 @@ en:
         must_have_mitglied_role: ""
         must_have_mitglied_role_in_group: ""
         must_have_one_family_main_person_in_family: ""
-          
+
       models:
         course_compensation_rate:
           attributes:
@@ -511,11 +511,11 @@ en:
         one: ''
         other: ''
 
-      group/abonnenten:
+      group/abos:
         one: ''
         other: ''
 
-      group/abo_magazin:
+      group/abo_magazine:
         one: ''
         other: ''
 
@@ -645,13 +645,19 @@ en:
       group/externe_kontakte/kontakt:
         one: ""
         description: ""
+      group/abo_magazine/autor:
+        one: ""
+        description: ""
+      group/abo_magazine/andere:
+        one: ""
+        description: ""
+      group/abo_magazine/uebersetzer:
+        one: ""
+        description: ""
       group/abo_magazin/abonnent:
         one: ""
         description: ""
       group/abo_magazin/neuanmeldung:
-        one: ""
-        description: ""
-      group/abo_magazin/autor:
         one: ""
         description: ""
       group/abo_magazin/andere:

--- a/config/locales/wagon.fr.yml
+++ b/config/locales/wagon.fr.yml
@@ -535,6 +535,11 @@ fr:
         many: ''
         other: ''
 
+      group/abo_magazin:
+        one: ''
+        many: ''
+        other: ''
+
       group/abo_magazine:
         one: ''
         many: ''

--- a/config/locales/wagon.fr.yml
+++ b/config/locales/wagon.fr.yml
@@ -413,7 +413,7 @@ fr:
         total: ""
         issued_at: ""
         created_at: ""
-        updated_at: ""            
+        updated_at: ""
         states:
           draft: ""
           open: ""
@@ -432,7 +432,7 @@ fr:
         must_have_mitglied_role: ""
         must_have_mitglied_role_in_group: ""
         must_have_one_family_main_person_in_family: ""
-          
+
       models:
         course_compensation_rate:
           attributes:
@@ -530,12 +530,12 @@ fr:
         many: ''
         other: ''
 
-      group/abonnenten:
+      group/abos:
         one: ''
         many: ''
         other: ''
 
-      group/abo_magazin:
+      group/abo_magazine:
         one: ''
         many: ''
         other: ''
@@ -686,13 +686,19 @@ fr:
       group/externe_kontakte/kontakt:
         one: ""
         description: ""
+      group/abo_magazine/autor:
+        one: ""
+        description: ""
+      group/abo_magazine/andere:
+        one: ""
+        description: ""
+      group/abo_magazine/uebersetzer:
+        one: ""
+        description: ""
       group/abo_magazin/abonnent:
         one: ""
         description: ""
       group/abo_magazin/neuanmeldung:
-        one: ""
-        description: ""
-      group/abo_magazin/autor:
         one: ""
         description: ""
       group/abo_magazin/andere:

--- a/config/locales/wagon.fr.yml
+++ b/config/locales/wagon.fr.yml
@@ -722,6 +722,9 @@ fr:
       group/abo_touren_portal/andere:
         one: ""
         description: ""
+      group/abo_touren_portal/gratisabonnent:
+        one: ""
+        description: ""
       group/abo_basic_login/basic_login:
         one: ""
         description: ""

--- a/config/locales/wagon.it.yml
+++ b/config/locales/wagon.it.yml
@@ -535,6 +535,11 @@ it:
         many: ''
         other: ''
 
+      group/abo_magazin:
+        one: ''
+        many: ''
+        other: ''
+
       group/abo_magazine:
         one: ''
         many: ''

--- a/config/locales/wagon.it.yml
+++ b/config/locales/wagon.it.yml
@@ -413,7 +413,7 @@ it:
         total: ""
         issued_at: ""
         created_at: ""
-        updated_at: ""            
+        updated_at: ""
         states:
           draft: ""
           open: ""
@@ -432,7 +432,7 @@ it:
         must_have_mitglied_role: ""
         must_have_mitglied_role_in_group: ""
         must_have_one_family_main_person_in_family: ""
-          
+
       models:
         course_compensation_rate:
           attributes:
@@ -530,12 +530,12 @@ it:
         many: ''
         other: ''
 
-      group/abonnenten:
+      group/abos:
         one: ''
         many: ''
         other: ''
 
-      group/abo_magazin:
+      group/abo_magazine:
         one: ''
         many: ''
         other: ''
@@ -686,13 +686,19 @@ it:
       group/externe_kontakte/kontakt:
         one: ""
         description: ""
+      group/abo_magazine/autor:
+        one: ""
+        description: ""
+      group/abo_magazine/andere:
+        one: ""
+        description: ""
+      group/abo_magazine/uebersetzer:
+        one: ""
+        description: ""
       group/abo_magazin/abonnent:
         one: ""
         description: ""
       group/abo_magazin/neuanmeldung:
-        one: ""
-        description: ""
-      group/abo_magazin/autor:
         one: ""
         description: ""
       group/abo_magazin/andere:

--- a/config/locales/wagon.it.yml
+++ b/config/locales/wagon.it.yml
@@ -722,6 +722,9 @@ it:
       group/abo_touren_portal/andere:
         one: ""
         description: ""
+      group/abo_touren_portal/gratisabonnent:
+        one: ""
+        description: ""
       group/abo_basic_login/basic_login:
         one: ""
         description: ""

--- a/db/seeds/groups.rb
+++ b/db/seeds/groups.rb
@@ -15,19 +15,22 @@ end
 
 Group::SacCas.seed_once(:parent_id, name: "SAC/CAS")
 
-Group::Abonnenten.seed_once(:parent_id, parent_id: Group.root.id)
-abonnenten = Group::Abonnenten.find_by(parent_id: Group.root.id)
+Group::Abos.seed_once(:parent_id, parent_id: Group.root.id)
+abos = Group::Abos.find_by(parent_id: Group.root.id)
 
-seed_magazin_abo("Die Alpen DE", abonnenten)
-seed_magazin_abo("Les Alpes FR", abonnenten)
-seed_magazin_abo("Le Alpi IT", abonnenten)
+Group::AboMagazine.seed_once(:parent_id, parent_id: abos.id)
+magazine = Group::AboMagazine.find_by(parent_id: abos.id)
+
+seed_magazin_abo("Die Alpen DE", magazine)
+seed_magazin_abo("Les Alpes FR", magazine)
+seed_magazin_abo("Le Alpi IT", magazine)
 
 Group::AboTourenPortal.seed_once(:parent_id) do |a|
-  a.parent_id = abonnenten.id
+  a.parent_id = abos.id
   a.self_registration_role_type = "Group::AboTourenPortal::Abonnent"
 end
 
 Group::AboBasicLogin.seed_once(:parent_id) do |a|
-  a.parent_id = abonnenten.id
+  a.parent_id = abos.id
   a.self_registration_role_type = "Group::AboBasicLogin::BasicLogin"
 end

--- a/spec/domain/oidc_claim_setup_spec.rb
+++ b/spec/domain/oidc_claim_setup_spec.rb
@@ -172,7 +172,7 @@ describe OidcClaimSetup do
     end
 
     it "includes magazin_subscriber key when matching role exists" do
-      group = Fabricate(Group::AboMagazin.sti_name, parent: groups(:abos))
+      group = Fabricate(Group::AboMagazin.sti_name, parent: groups(:abo_magazine))
       create_role(group, "Andere")
       expect(user_groups).to include "magazin_subscriber"
     end

--- a/spec/domain/oidc_claim_setup_spec.rb
+++ b/spec/domain/oidc_claim_setup_spec.rb
@@ -116,7 +116,7 @@ describe OidcClaimSetup do
     end
 
     it "includes SAC_tourenportal_subscriber key when matching role exists" do
-      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abos))
       create_role(group, "Autor")
       expect(user_groups).to include "SAC_tourenportal_subscriber"
     end
@@ -142,31 +142,37 @@ describe OidcClaimSetup do
     end
 
     it "includes tourenportal_author key when matching role exists" do
-      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abos))
       create_role(group, "Autor")
       expect(user_groups).to include "tourenportal_author"
     end
 
     it "includes tourenportal_community key when matching role exists" do
-      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abos))
       create_role(group, "Community")
       expect(user_groups).to include "tourenportal_community"
     end
 
     it "includes tourenportal_community key when matching role exists" do
-      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abos))
       create_role(group, "Community")
       expect(user_groups).to include "tourenportal_community"
     end
 
     it "includes tourenportal_administrator key when matching role exists" do
-      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten))
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abos))
       create_role(group, "Admin")
       expect(user_groups).to include "tourenportal_administrator"
     end
 
+    it "includes tourenportal_gratisabonnent key when matching role exists" do
+      group = Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abos))
+      create_role(group, "Gratisabonnent")
+      expect(user_groups).to include "tourenportal_gratisabonnent"
+    end
+
     it "includes magazin_subscriber key when matching role exists" do
-      group = Fabricate(Group::AboMagazin.sti_name, parent: groups(:abonnenten))
+      group = Fabricate(Group::AboMagazin.sti_name, parent: groups(:abos))
       create_role(group, "Andere")
       expect(user_groups).to include "magazin_subscriber"
     end

--- a/spec/features/signup/abo_basic_login_spec.rb
+++ b/spec/features/signup/abo_basic_login_spec.rb
@@ -8,7 +8,7 @@
 require "spec_helper"
 
 describe :self_registration do
-  let(:group) { Fabricate(Group::AboBasicLogin.sti_name, parent: groups(:abonnenten)) }
+  let(:group) { Fabricate(Group::AboBasicLogin.sti_name, parent: groups(:abos)) }
 
   before do
     group.update!(self_registration_role_type: group.role_types.first)

--- a/spec/features/signup/abo_touren_portal_spec.rb
+++ b/spec/features/signup/abo_touren_portal_spec.rb
@@ -8,7 +8,7 @@
 require "spec_helper"
 
 describe "signup/abo_touren_portal_wizard" do
-  let(:group) { Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten)) }
+  let(:group) { Fabricate(Group::AboTourenPortal.sti_name, parent: groups(:abos)) }
 
   before do
     group.update!(self_registration_role_type: group.role_types.first)

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -6,7 +6,7 @@
 root:
   parent:
   lft: 1
-  rgt: 46
+  rgt: 47
   name: SAC/CAS
   type: Group::SacCas
   email: root@example.net
@@ -28,15 +28,23 @@ geschaeftsstelle:
 abos:
   parent: root
   lft: 4
-  rgt: 7
+  rgt: 9
   type: Group::Abos
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-abo_die_alpen:
+abo_magazine:
   parent: abos
   lft: 5
-  rgt: 6
+  rgt: 8
+  type: Group::AboMagazine
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+abo_die_alpen:
+  parent: abo_magazine
+  lft: 6
+  rgt: 7
   name: Die Alpen DE
   type: Group::AboMagazin
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
@@ -44,8 +52,8 @@ abo_die_alpen:
 
 externe_kontakte:
   parent: root
-  lft: 8
-  rgt: 9
+  lft: 10
+  rgt: 11
   name: Externe Kontakte
   type: Group::ExterneKontakte
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
@@ -53,8 +61,8 @@ externe_kontakte:
 
 bluemlisalp:
   parent: root
-  lft: 10
-  rgt: 33
+  lft: 12
+  rgt: 35
   name: SAC Blüemlisalp
   type: Group::Sektion
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
@@ -63,32 +71,32 @@ bluemlisalp:
 
 bluemlisalp_funktionaere:
   parent: bluemlisalp
-  lft: 25
-  rgt: 26
+  lft: 27
+  rgt: 28
   type: Group::SektionsFunktionaere
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 bluemlisalp_mitglieder:
   parent: bluemlisalp
-  lft: 27
-  rgt: 28
+  lft: 29
+  rgt: 30
   type: Group::SektionsMitglieder
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 bluemlisalp_neuanmeldungen_nv:
   parent: bluemlisalp
-  lft: 29
-  rgt: 30
+  lft: 31
+  rgt: 32
   type: Group::SektionsNeuanmeldungenNv
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 bluemlisalp_neuanmeldungen_sektion:
   parent: bluemlisalp
-  lft: 31
-  rgt: 32
+  lft: 33
+  rgt: 34
   type: Group::SektionsNeuanmeldungenSektion
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
   self_registration_role_type: Group::SektionsNeuanmeldungenSektion::Neuanmeldung
@@ -96,8 +104,8 @@ bluemlisalp_neuanmeldungen_sektion:
 
 bluemlisalp_ortsgruppe_ausserberg:
   parent: :bluemlisalp
-  lft: 11
-  rgt: 24
+  lft: 13
+  rgt: 26
   name: SAC Blüemlisalp Ausserberg
   type: Group::Ortsgruppe
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
@@ -106,40 +114,40 @@ bluemlisalp_ortsgruppe_ausserberg:
 
 bluemlisalp_ortsgruppe_ausserberg_mitglieder:
   parent: bluemlisalp_ortsgruppe_ausserberg
-  lft: 12
-  rgt: 13
+  lft: 14
+  rgt: 15
   type: Group::SektionsMitglieder
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 bluemlisalp_ortsgruppe_ausserberg_neuanmeldungen_nv:
   parent: bluemlisalp_ortsgruppe_ausserberg
-  lft: 14
-  rgt: 15
+  lft: 16
+  rgt: 17
   type: Group::SektionsNeuanmeldungenNv
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 bluemlisalp_ortsgruppe_ausserberg_funktionaere:
   parent: bluemlisalp_ortsgruppe_ausserberg
-  lft: 16
-  rgt: 23
+  lft: 18
+  rgt: 25
   type: Group::SektionsFunktionaere
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse:
   parent: bluemlisalp_ortsgruppe_ausserberg_funktionaere
-  lft: 17
-  rgt: 22
+  lft: 19
+  rgt: 24
   type: Group::SektionsTourenUndKurse
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse_sommer:
   parent: bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse
-  lft: 18
-  rgt: 19
+  lft: 20
+  rgt: 21
   name: Touren und Kurse Sommer
   type: Group::SektionsTourenUndKurseSommer
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
@@ -147,8 +155,8 @@ bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse_sommer:
 
 bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse_winter:
   parent: bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse
-  lft: 20
-  rgt: 21
+  lft: 22
+  rgt: 23
   name: Touren und Kurse Winter
   type: Group::SektionsTourenUndKurseWinter
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
@@ -156,8 +164,8 @@ bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse_winter:
 
 matterhorn:
   parent: root
-  lft: 34
-  rgt: 45
+  lft: 36
+  rgt: 47
   name: SAC Matterhorn
   type: Group::Sektion
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
@@ -165,32 +173,32 @@ matterhorn:
 
 matterhorn_funktionaere:
   parent: matterhorn
-  lft: 35
-  rgt: 36
+  lft: 37
+  rgt: 38
   type: Group::SektionsFunktionaere
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 matterhorn_mitglieder:
   parent: matterhorn
-  lft: 37
-  rgt: 38
+  lft: 39
+  rgt: 40
   type: Group::SektionsMitglieder
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 matterhorn_neuanmeldungen_nv:
   parent: matterhorn
-  lft: 39
-  rgt: 40
+  lft: 41
+  rgt: 42
   type: Group::SektionsNeuanmeldungenNv
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 matterhorn_neuanmeldungen_sektion:
   parent: matterhorn
-  lft: 41
-  rgt: 42
+  lft: 43
+  rgt: 44
   type: Group::SektionsNeuanmeldungenSektion
   self_registration_role_type: Group::SektionsNeuanmeldungenSektion::Neuanmeldung
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
@@ -198,8 +206,8 @@ matterhorn_neuanmeldungen_sektion:
 
 matterhorn_touren_und_kurse:
   parent: matterhorn
-  lft: 43
-  rgt: 44
+  lft: 45
+  rgt: 46
   type: Group::SektionsTourenUndKurse
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -6,7 +6,7 @@
 root:
   parent:
   lft: 1
-  rgt: 47
+  rgt: 48
   name: SAC/CAS
   type: Group::SacCas
   email: root@example.net

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -5,9 +5,8 @@
 
 root:
   parent:
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
   lft: 1
-  rgt: 94
+  rgt: 46
   name: SAC/CAS
   type: Group::SacCas
   email: root@example.net
@@ -15,443 +14,192 @@ root:
   housenumber: 79a
   zip_code: 2843
   town: Neu Carlscheid
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-sac_abos_ohne_newesletter_2:
+geschaeftsstelle:
   parent: root
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
-  lft: 78
-  rgt: 91
-  name: SAC Abos (ohne Newesletter)
-  short_name: SAC Abos (ohne Newesletter)
-  type: Group::Abos
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sac_magazin_3:
-  parent: sac_abos_ohne_newesletter_2
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
-  lft: 79
-  rgt: 86
-  name: SAC-Magazin
-  short_name: SAC-Magazin
-  type: Group::AboMagazine
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-die_alpen_de:
-  parent: sac_magazin_3
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
-  lft: 80
-  rgt: 81
-  name: Die Alpen DE
-  type: Group::AboMagazin
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-les_alpes_fr:
-  parent: sac_magazin_3
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
-  lft: 84
-  rgt: 85
-  name: Les Alpes FR
-  type: Group::AboMagazin
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-le_alpi_it:
-  parent: sac_magazin_3
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
-  lft: 82
-  rgt: 83
-  name: Le Alpi IT
-  type: Group::AboMagazin
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sac_tourenportal_7:
-  parent: sac_abos_ohne_newesletter_2
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
-  lft: 87
-  rgt: 88
-  name: SAC-Tourenportal
-  short_name: SAC-Tourenportal
-  type: Group::AboTourenPortal
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sac_cas_login_8:
-  parent: sac_abos_ohne_newesletter_2
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
-  lft: 89
-  rgt: 90
-  name: SAC/CAS Login
-  short_name: SAC/CAS Login
-  type: Group::AboBasicLogin
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sac_geschaeftsstelle_9:
-  parent: root
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
-  lft: 92
-  rgt: 93
-  name: SAC Geschäftsstelle
-  short_name: SAC Geschäftsstelle
-  type: Group::Geschaeftsstelle
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-2_externe_kontakte:
-  parent: root
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
   lft: 2
+  rgt: 3
+  type: Group::Geschaeftsstelle
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+abos:
+  parent: root
+  lft: 4
   rgt: 7
-  name: 2 Externe Kontakte
-  type: Group::ExterneKontakte
+  type: Group::Abos
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-autoren:
-  parent: 2_externe_kontakte
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
-  lft: 3
-  rgt: 4
-  name: Autoren
-  type: Group::ExterneKontakte
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-druckereien:
-  parent: 2_externe_kontakte
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+abo_die_alpen:
+  parent: abos
   lft: 5
   rgt: 6
-  name: Druckereien
-  type: Group::ExterneKontakte
+  name: Die Alpen DE
+  type: Group::AboMagazin
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-sac_matterhorn:
+externe_kontakte:
   parent: root
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
-  lft: 38
-  rgt: 55
-  name: SAC Matterhorn
-  type: Group::Sektion
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sektionsfunktionaere_14:
-  parent: sac_matterhorn
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
-  lft: 43
-  rgt: 54
-  name: Sektionsfunktionäre
-  short_name: Sektionsfunktionäre
-  type: Group::SektionsFunktionaere
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-vorstand_15:
-  parent: sektionsfunktionaere_14
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
-  lft: 52
-  rgt: 53
-  name: Vorstand
-  type: Group::SektionsVorstand
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-touren_und_kurse_16:
-  parent: sektionsfunktionaere_14
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
-  lft: 50
-  rgt: 51
-  name: Touren und Kurse
-  short_name: Touren und Kurse
-  type: Group::SektionsTourenUndKurse
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-kommissionen_17:
-  parent: sektionsfunktionaere_14
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
-  lft: 44
-  rgt: 45
-  name: Kommissionen
-  short_name: Kommissionen
-  type: Group::SektionsKommissionen
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-mitglieder_18:
-  parent: sac_matterhorn
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
-  lft: 39
-  rgt: 40
-  name: Mitglieder
-  short_name: Mitglieder
-  type: Group::SektionsMitglieder
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-neuanmeldungen_19:
-  parent: sac_matterhorn
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
-  lft: 41
-  rgt: 42
-  name: Neuanmeldungen
-  short_name: Neuanmeldungen
-  type: Group::SektionsNeuanmeldungenNv
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sac_uto:
-  parent: root
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 56
-  rgt: 77
-  name: SAC UTO
-  type: Group::Sektion
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sektionsfunktionaere_21:
-  parent: sac_uto
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 61
-  rgt: 76
-  name: Sektionsfunktionäre
-  short_name: Sektionsfunktionäre
-  type: Group::SektionsFunktionaere
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-vorstand_22:
-  parent: sektionsfunktionaere_21
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 74
-  rgt: 75
-  name: Vorstand
-  type: Group::SektionsVorstand
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-touren_und_kurse_23:
-  parent: sektionsfunktionaere_21
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 72
-  rgt: 73
-  name: Touren und Kurse
-  short_name: Touren und Kurse
-  type: Group::SektionsTourenUndKurse
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-kommissionen_24:
-  parent: sektionsfunktionaere_21
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 70
-  rgt: 71
-  name: Kommissionen
-  short_name: Kommissionen
-  type: Group::SektionsKommissionen
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-mitglieder_25:
-  parent: sac_uto
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 57
-  rgt: 58
-  name: Mitglieder
-  short_name: Mitglieder
-  type: Group::SektionsMitglieder
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-neuanmeldungen_26:
-  parent: sac_uto
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 59
-  rgt: 60
-  name: Neuanmeldungen
-  short_name: Neuanmeldungen
-  type: Group::SektionsNeuanmeldungenNv
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sac_blueemlisalp:
-  parent: root
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
   lft: 8
-  rgt: 37
+  rgt: 9
+  name: Externe Kontakte
+  type: Group::ExterneKontakte
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+bluemlisalp:
+  parent: root
+  lft: 10
+  rgt: 33
   name: SAC Blüemlisalp
   type: Group::Sektion
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
+  navision_id: 1650
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-sektionsfunktionaere_28:
-  parent: sac_blueemlisalp
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 15
-  rgt: 36
-  name: Sektionsfunktionäre
-  short_name: Sektionsfunktionäre
+bluemlisalp_funktionaere:
+  parent: bluemlisalp
+  lft: 25
+  rgt: 26
   type: Group::SektionsFunktionaere
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-vorstand_29:
-  parent: sektionsfunktionaere_28
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 34
-  rgt: 35
-  name: Vorstand
-  type: Group::SektionsVorstand
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-touren_und_kurse_30:
-  parent: sektionsfunktionaere_28
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 32
-  rgt: 33
-  name: Touren und Kurse
-  short_name: Touren und Kurse
-  type: Group::SektionsTourenUndKurse
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-kommissionen_31:
-  parent: sektionsfunktionaere_28
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 24
-  rgt: 25
-  name: Kommissionen
-  short_name: Kommissionen
-  type: Group::SektionsKommissionen
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-mitglieder_32:
-  parent: sac_blueemlisalp
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 9
-  rgt: 10
-  name: Mitglieder
-  short_name: Mitglieder
-  type: Group::SektionsMitglieder
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-neuanmeldungen_33:
-  parent: sac_blueemlisalp
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 11
-  rgt: 12
-  name: Neuanmeldungen
-  short_name: Neuanmeldungen
-  type: Group::SektionsNeuanmeldungenNv
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-neuanmeldungen_zur_freigabe_34:
-  parent: sac_blueemlisalp
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 13
-  rgt: 14
-  name: Neuanmeldungen (zur Freigabe)
-  short_name: Neuanmeldungen (zur Freigabe)
-  type: Group::SektionsNeuanmeldungenSektion
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sektionshuetten_35:
-  parent: sektionsfunktionaere_14
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
-  lft: 46
-  rgt: 49
-  name: Sektionshütten
-  short_name: Sektionshütten
-  type: Group::Sektionshuetten
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-matterhornbiwak:
-  parent: sektionshuetten_35
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
-  lft: 47
-  rgt: 48
-  name: Matterhornbiwak
-  type: Group::Sektionshuette
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-clubhuetten_37:
-  parent: sektionsfunktionaere_21
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 62
-  rgt: 69
-  name: Clubhütten
-  short_name: Clubhütten
-  type: Group::SektionsClubhuetten
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-domhuette:
-  parent: clubhuetten_37
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 63
-  rgt: 64
-  name: Domhütte
-  type: Group::SektionsClubhuette
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-spannorthuette:
-  parent: clubhuetten_37
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 65
-  rgt: 66
-  name: Spannorthütte
-  type: Group::SektionsClubhuette
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-taeschhuette:
-  parent: clubhuetten_37
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
-  lft: 67
-  rgt: 68
-  name: Täschhütte
-  type: Group::SektionsClubhuette
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-clubhuetten_41:
-  parent: sektionsfunktionaere_28
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 16
-  rgt: 23
-  name: Clubhütten
-  short_name: Clubhütten
-  type: Group::SektionsClubhuetten
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-blueemlisalphuette:
-  parent: clubhuetten_41
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 19
-  rgt: 20
-  name: Blüemlisalphütte
-  type: Group::SektionsClubhuette
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-baltschiederklause:
-  parent: clubhuetten_41
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 17
-  rgt: 18
-  name: Baltschiederklause
-  type: Group::SektionsClubhuette
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-stockhornbiwak:
-  parent: clubhuetten_41
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 21
-  rgt: 22
-  name: Stockhornbiwak
-  type: Group::SektionsClubhuette
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-sektionshuetten_45:
-  parent: sektionsfunktionaere_28
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
-  lft: 26
-  rgt: 31
-  name: Sektionshütten
-  short_name: Sektionshütten
-  type: Group::Sektionshuetten
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-ski_ferienhaus_obergestelen:
-  parent: sektionshuetten_45
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+bluemlisalp_mitglieder:
+  parent: bluemlisalp
   lft: 27
   rgt: 28
-  name: Ski- & Ferienhaus Obergestelen
-  type: Group::Sektionshuette
+  type: Group::SektionsMitglieder
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-sunnhuesi:
-  parent: sektionshuetten_45
-  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+bluemlisalp_neuanmeldungen_nv:
+  parent: bluemlisalp
   lft: 29
   rgt: 30
-  name: Sunnhüsi
-  type: Group::Sektionshuette
+  type: Group::SektionsNeuanmeldungenNv
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+bluemlisalp_neuanmeldungen_sektion:
+  parent: bluemlisalp
+  lft: 31
+  rgt: 32
+  type: Group::SektionsNeuanmeldungenSektion
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
+  self_registration_role_type: Group::SektionsNeuanmeldungenSektion::Neuanmeldung
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+bluemlisalp_ortsgruppe_ausserberg:
+  parent: :bluemlisalp
+  lft: 11
+  rgt: 24
+  name: SAC Blüemlisalp Ausserberg
+  type: Group::Ortsgruppe
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
+  navision_id: 1651
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+bluemlisalp_ortsgruppe_ausserberg_mitglieder:
+  parent: bluemlisalp_ortsgruppe_ausserberg
+  lft: 12
+  rgt: 13
+  type: Group::SektionsMitglieder
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+bluemlisalp_ortsgruppe_ausserberg_neuanmeldungen_nv:
+  parent: bluemlisalp_ortsgruppe_ausserberg
+  lft: 14
+  rgt: 15
+  type: Group::SektionsNeuanmeldungenNv
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+bluemlisalp_ortsgruppe_ausserberg_funktionaere:
+  parent: bluemlisalp_ortsgruppe_ausserberg
+  lft: 16
+  rgt: 23
+  type: Group::SektionsFunktionaere
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse:
+  parent: bluemlisalp_ortsgruppe_ausserberg_funktionaere
+  lft: 17
+  rgt: 22
+  type: Group::SektionsTourenUndKurse
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse_sommer:
+  parent: bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse
+  lft: 18
+  rgt: 19
+  name: Touren und Kurse Sommer
+  type: Group::SektionsTourenUndKurseSommer
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse_winter:
+  parent: bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse
+  lft: 20
+  rgt: 21
+  name: Touren und Kurse Winter
+  type: Group::SektionsTourenUndKurseWinter
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+matterhorn:
+  parent: root
+  lft: 34
+  rgt: 45
+  name: SAC Matterhorn
+  type: Group::Sektion
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+matterhorn_funktionaere:
+  parent: matterhorn
+  lft: 35
+  rgt: 36
+  type: Group::SektionsFunktionaere
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+matterhorn_mitglieder:
+  parent: matterhorn
+  lft: 37
+  rgt: 38
+  type: Group::SektionsMitglieder
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+matterhorn_neuanmeldungen_nv:
+  parent: matterhorn
+  lft: 39
+  rgt: 40
+  type: Group::SektionsNeuanmeldungenNv
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+matterhorn_neuanmeldungen_sektion:
+  parent: matterhorn
+  lft: 41
+  rgt: 42
+  type: Group::SektionsNeuanmeldungenSektion
+  self_registration_role_type: Group::SektionsNeuanmeldungenSektion::Neuanmeldung
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+matterhorn_touren_und_kurse:
+  parent: matterhorn
+  lft: 43
+  rgt: 44
+  type: Group::SektionsTourenUndKurse
+  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -25,16 +25,16 @@ geschaeftsstelle:
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-abonnenten:
+abos:
   parent: root
   lft: 4
   rgt: 7
-  type: Group::Abonnenten
+  type: Group::Abos
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
 abo_die_alpen:
-  parent: abonnenten
+  parent: abos
   lft: 5
   rgt: 6
   name: Die Alpen DE

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -5,8 +5,9 @@
 
 root:
   parent:
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
   lft: 1
-  rgt: 46
+  rgt: 94
   name: SAC/CAS
   type: Group::SacCas
   email: root@example.net
@@ -14,192 +15,443 @@ root:
   housenumber: 79a
   zip_code: 2843
   town: Neu Carlscheid
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-geschaeftsstelle:
+sac_abos_ohne_newesletter_2:
   parent: root
-  lft: 2
-  rgt: 3
-  type: Group::Geschaeftsstelle
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-abos:
-  parent: root
-  lft: 4
-  rgt: 7
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 78
+  rgt: 91
+  name: SAC Abos (ohne Newesletter)
+  short_name: SAC Abos (ohne Newesletter)
   type: Group::Abos
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-abo_die_alpen:
-  parent: abos
-  lft: 5
-  rgt: 6
+sac_magazin_3:
+  parent: sac_abos_ohne_newesletter_2
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 79
+  rgt: 86
+  name: SAC-Magazin
+  short_name: SAC-Magazin
+  type: Group::AboMagazine
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+die_alpen_de:
+  parent: sac_magazin_3
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 80
+  rgt: 81
   name: Die Alpen DE
   type: Group::AboMagazin
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-externe_kontakte:
+les_alpes_fr:
+  parent: sac_magazin_3
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 84
+  rgt: 85
+  name: Les Alpes FR
+  type: Group::AboMagazin
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+le_alpi_it:
+  parent: sac_magazin_3
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 82
+  rgt: 83
+  name: Le Alpi IT
+  type: Group::AboMagazin
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sac_tourenportal_7:
+  parent: sac_abos_ohne_newesletter_2
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 87
+  rgt: 88
+  name: SAC-Tourenportal
+  short_name: SAC-Tourenportal
+  type: Group::AboTourenPortal
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sac_cas_login_8:
+  parent: sac_abos_ohne_newesletter_2
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 89
+  rgt: 90
+  name: SAC/CAS Login
+  short_name: SAC/CAS Login
+  type: Group::AboBasicLogin
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sac_geschaeftsstelle_9:
   parent: root
-  lft: 8
-  rgt: 9
-  name: Externe Kontakte
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 92
+  rgt: 93
+  name: SAC Geschäftsstelle
+  short_name: SAC Geschäftsstelle
+  type: Group::Geschaeftsstelle
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+2_externe_kontakte:
+  parent: root
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 2
+  rgt: 7
+  name: 2 Externe Kontakte
   type: Group::ExterneKontakte
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-bluemlisalp:
+autoren:
+  parent: 2_externe_kontakte
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 3
+  rgt: 4
+  name: Autoren
+  type: Group::ExterneKontakte
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+druckereien:
+  parent: 2_externe_kontakte
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 5
+  rgt: 6
+  name: Druckereien
+  type: Group::ExterneKontakte
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sac_matterhorn:
   parent: root
-  lft: 10
-  rgt: 33
-  name: SAC Blüemlisalp
-  type: Group::Sektion
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
-  navision_id: 1650
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_funktionaere:
-  parent: bluemlisalp
-  lft: 25
-  rgt: 26
-  type: Group::SektionsFunktionaere
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_mitglieder:
-  parent: bluemlisalp
-  lft: 27
-  rgt: 28
-  type: Group::SektionsMitglieder
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_neuanmeldungen_nv:
-  parent: bluemlisalp
-  lft: 29
-  rgt: 30
-  type: Group::SektionsNeuanmeldungenNv
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_neuanmeldungen_sektion:
-  parent: bluemlisalp
-  lft: 31
-  rgt: 32
-  type: Group::SektionsNeuanmeldungenSektion
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp) %>
-  self_registration_role_type: Group::SektionsNeuanmeldungenSektion::Neuanmeldung
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_ortsgruppe_ausserberg:
-  parent: :bluemlisalp
-  lft: 11
-  rgt: 24
-  name: SAC Blüemlisalp Ausserberg
-  type: Group::Ortsgruppe
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
-  navision_id: 1651
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_ortsgruppe_ausserberg_mitglieder:
-  parent: bluemlisalp_ortsgruppe_ausserberg
-  lft: 12
-  rgt: 13
-  type: Group::SektionsMitglieder
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_ortsgruppe_ausserberg_neuanmeldungen_nv:
-  parent: bluemlisalp_ortsgruppe_ausserberg
-  lft: 14
-  rgt: 15
-  type: Group::SektionsNeuanmeldungenNv
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_ortsgruppe_ausserberg_funktionaere:
-  parent: bluemlisalp_ortsgruppe_ausserberg
-  lft: 16
-  rgt: 23
-  type: Group::SektionsFunktionaere
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse:
-  parent: bluemlisalp_ortsgruppe_ausserberg_funktionaere
-  lft: 17
-  rgt: 22
-  type: Group::SektionsTourenUndKurse
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse_sommer:
-  parent: bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse
-  lft: 18
-  rgt: 19
-  name: Touren und Kurse Sommer
-  type: Group::SektionsTourenUndKurseSommer
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse_winter:
-  parent: bluemlisalp_ortsgruppe_ausserberg_touren_und_kurse
-  lft: 20
-  rgt: 21
-  name: Touren und Kurse Winter
-  type: Group::SektionsTourenUndKurseWinter
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:bluemlisalp_ortsgruppe_ausserberg) %>
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
-
-matterhorn:
-  parent: root
-  lft: 34
-  rgt: 45
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
+  lft: 38
+  rgt: 55
   name: SAC Matterhorn
   type: Group::Sektion
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-matterhorn_funktionaere:
-  parent: matterhorn
-  lft: 35
-  rgt: 36
+sektionsfunktionaere_14:
+  parent: sac_matterhorn
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
+  lft: 43
+  rgt: 54
+  name: Sektionsfunktionäre
+  short_name: Sektionsfunktionäre
   type: Group::SektionsFunktionaere
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-matterhorn_mitglieder:
-  parent: matterhorn
-  lft: 37
-  rgt: 38
-  type: Group::SektionsMitglieder
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
+vorstand_15:
+  parent: sektionsfunktionaere_14
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
+  lft: 52
+  rgt: 53
+  name: Vorstand
+  type: Group::SektionsVorstand
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-matterhorn_neuanmeldungen_nv:
-  parent: matterhorn
+touren_und_kurse_16:
+  parent: sektionsfunktionaere_14
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
+  lft: 50
+  rgt: 51
+  name: Touren und Kurse
+  short_name: Touren und Kurse
+  type: Group::SektionsTourenUndKurse
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+kommissionen_17:
+  parent: sektionsfunktionaere_14
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
+  lft: 44
+  rgt: 45
+  name: Kommissionen
+  short_name: Kommissionen
+  type: Group::SektionsKommissionen
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+mitglieder_18:
+  parent: sac_matterhorn
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
   lft: 39
   rgt: 40
-  type: Group::SektionsNeuanmeldungenNv
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
+  name: Mitglieder
+  short_name: Mitglieder
+  type: Group::SektionsMitglieder
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-matterhorn_neuanmeldungen_sektion:
-  parent: matterhorn
+neuanmeldungen_19:
+  parent: sac_matterhorn
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
   lft: 41
   rgt: 42
-  type: Group::SektionsNeuanmeldungenSektion
-  self_registration_role_type: Group::SektionsNeuanmeldungenSektion::Neuanmeldung
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
+  name: Neuanmeldungen
+  short_name: Neuanmeldungen
+  type: Group::SektionsNeuanmeldungenNv
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
 
-matterhorn_touren_und_kurse:
-  parent: matterhorn
-  lft: 43
-  rgt: 44
+sac_uto:
+  parent: root
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 56
+  rgt: 77
+  name: SAC UTO
+  type: Group::Sektion
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sektionsfunktionaere_21:
+  parent: sac_uto
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 61
+  rgt: 76
+  name: Sektionsfunktionäre
+  short_name: Sektionsfunktionäre
+  type: Group::SektionsFunktionaere
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+vorstand_22:
+  parent: sektionsfunktionaere_21
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 74
+  rgt: 75
+  name: Vorstand
+  type: Group::SektionsVorstand
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+touren_und_kurse_23:
+  parent: sektionsfunktionaere_21
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 72
+  rgt: 73
+  name: Touren und Kurse
+  short_name: Touren und Kurse
   type: Group::SektionsTourenUndKurse
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:matterhorn) %>
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+kommissionen_24:
+  parent: sektionsfunktionaere_21
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 70
+  rgt: 71
+  name: Kommissionen
+  short_name: Kommissionen
+  type: Group::SektionsKommissionen
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+mitglieder_25:
+  parent: sac_uto
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 57
+  rgt: 58
+  name: Mitglieder
+  short_name: Mitglieder
+  type: Group::SektionsMitglieder
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+neuanmeldungen_26:
+  parent: sac_uto
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 59
+  rgt: 60
+  name: Neuanmeldungen
+  short_name: Neuanmeldungen
+  type: Group::SektionsNeuanmeldungenNv
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sac_blueemlisalp:
+  parent: root
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 8
+  rgt: 37
+  name: SAC Blüemlisalp
+  type: Group::Sektion
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sektionsfunktionaere_28:
+  parent: sac_blueemlisalp
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 15
+  rgt: 36
+  name: Sektionsfunktionäre
+  short_name: Sektionsfunktionäre
+  type: Group::SektionsFunktionaere
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+vorstand_29:
+  parent: sektionsfunktionaere_28
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 34
+  rgt: 35
+  name: Vorstand
+  type: Group::SektionsVorstand
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+touren_und_kurse_30:
+  parent: sektionsfunktionaere_28
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 32
+  rgt: 33
+  name: Touren und Kurse
+  short_name: Touren und Kurse
+  type: Group::SektionsTourenUndKurse
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+kommissionen_31:
+  parent: sektionsfunktionaere_28
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 24
+  rgt: 25
+  name: Kommissionen
+  short_name: Kommissionen
+  type: Group::SektionsKommissionen
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+mitglieder_32:
+  parent: sac_blueemlisalp
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 9
+  rgt: 10
+  name: Mitglieder
+  short_name: Mitglieder
+  type: Group::SektionsMitglieder
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+neuanmeldungen_33:
+  parent: sac_blueemlisalp
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 11
+  rgt: 12
+  name: Neuanmeldungen
+  short_name: Neuanmeldungen
+  type: Group::SektionsNeuanmeldungenNv
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+neuanmeldungen_zur_freigabe_34:
+  parent: sac_blueemlisalp
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 13
+  rgt: 14
+  name: Neuanmeldungen (zur Freigabe)
+  short_name: Neuanmeldungen (zur Freigabe)
+  type: Group::SektionsNeuanmeldungenSektion
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sektionshuetten_35:
+  parent: sektionsfunktionaere_14
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
+  lft: 46
+  rgt: 49
+  name: Sektionshütten
+  short_name: Sektionshütten
+  type: Group::Sektionshuetten
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+matterhornbiwak:
+  parent: sektionshuetten_35
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_matterhorn)%>"
+  lft: 47
+  rgt: 48
+  name: Matterhornbiwak
+  type: Group::Sektionshuette
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+clubhuetten_37:
+  parent: sektionsfunktionaere_21
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 62
+  rgt: 69
+  name: Clubhütten
+  short_name: Clubhütten
+  type: Group::SektionsClubhuetten
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+domhuette:
+  parent: clubhuetten_37
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 63
+  rgt: 64
+  name: Domhütte
+  type: Group::SektionsClubhuette
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+spannorthuette:
+  parent: clubhuetten_37
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 65
+  rgt: 66
+  name: Spannorthütte
+  type: Group::SektionsClubhuette
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+taeschhuette:
+  parent: clubhuetten_37
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_uto)%>"
+  lft: 67
+  rgt: 68
+  name: Täschhütte
+  type: Group::SektionsClubhuette
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+clubhuetten_41:
+  parent: sektionsfunktionaere_28
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 16
+  rgt: 23
+  name: Clubhütten
+  short_name: Clubhütten
+  type: Group::SektionsClubhuetten
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+blueemlisalphuette:
+  parent: clubhuetten_41
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 19
+  rgt: 20
+  name: Blüemlisalphütte
+  type: Group::SektionsClubhuette
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+baltschiederklause:
+  parent: clubhuetten_41
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 17
+  rgt: 18
+  name: Baltschiederklause
+  type: Group::SektionsClubhuette
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+stockhornbiwak:
+  parent: clubhuetten_41
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 21
+  rgt: 22
+  name: Stockhornbiwak
+  type: Group::SektionsClubhuette
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sektionshuetten_45:
+  parent: sektionsfunktionaere_28
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 26
+  rgt: 31
+  name: Sektionshütten
+  short_name: Sektionshütten
+  type: Group::Sektionshuetten
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+ski_ferienhaus_obergestelen:
+  parent: sektionshuetten_45
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 27
+  rgt: 28
+  name: Ski- & Ferienhaus Obergestelen
+  type: Group::Sektionshuette
+  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+
+sunnhuesi:
+  parent: sektionshuetten_45
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sac_blueemlisalp)%>"
+  lft: 29
+  rgt: 30
+  name: Sunnhüsi
+  type: Group::Sektionshuette
   created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK

--- a/spec/models/memberships/terminate_sac_membership_spec.rb
+++ b/spec/models/memberships/terminate_sac_membership_spec.rb
@@ -128,7 +128,7 @@ describe Memberships::TerminateSacMembership do
       end
 
       describe "data_retention" do
-        let(:abonnenten) { groups(:abonnenten) }
+        let(:abonnenten) { groups(:abos) }
         let!(:basic) do
           Fabricate(:group, type: Group::AboBasicLogin.sti_name, parent: abonnenten)
         end

--- a/spec/models/wizards/signup/abo_basic_login_wizard_spec.rb
+++ b/spec/models/wizards/signup/abo_basic_login_wizard_spec.rb
@@ -9,7 +9,7 @@ require "spec_helper"
 
 describe Wizards::Signup::AboBasicLoginWizard do
   let(:group) do
-    Fabricate.build(Group::AboBasicLogin.sti_name, parent: groups(:abonnenten)).tap do |group|
+    Fabricate.build(Group::AboBasicLogin.sti_name, parent: groups(:abos)).tap do |group|
       group.self_registration_role_type = Group::AboBasicLogin::BasicLogin.sti_name
     end
   end

--- a/spec/models/wizards/signup/abo_magazin_wizard_spec.rb
+++ b/spec/models/wizards/signup/abo_magazin_wizard_spec.rb
@@ -9,7 +9,7 @@ require "spec_helper"
 
 describe Wizards::Signup::AboMagazinWizard do
   let(:group) do
-    Fabricate.build(Group::AboMagazin.sti_name, parent: groups(:abos)).tap do |group|
+    Fabricate.build(Group::AboMagazin.sti_name, parent: groups(:abo_magazine)).tap do |group|
       group.self_registration_role_type = Group::AboMagazin::Abonnent.sti_name
     end
   end

--- a/spec/models/wizards/signup/abo_magazin_wizard_spec.rb
+++ b/spec/models/wizards/signup/abo_magazin_wizard_spec.rb
@@ -9,7 +9,7 @@ require "spec_helper"
 
 describe Wizards::Signup::AboMagazinWizard do
   let(:group) do
-    Fabricate.build(Group::AboMagazin.sti_name, parent: groups(:abonnenten)).tap do |group|
+    Fabricate.build(Group::AboMagazin.sti_name, parent: groups(:abos)).tap do |group|
       group.self_registration_role_type = Group::AboMagazin::Abonnent.sti_name
     end
   end

--- a/spec/models/wizards/signup/abo_touren_portal_wizard_spec.rb
+++ b/spec/models/wizards/signup/abo_touren_portal_wizard_spec.rb
@@ -9,7 +9,7 @@ require "spec_helper"
 
 describe Wizards::Signup::AboTourenPortalWizard do
   let(:group) do
-    Fabricate.build(Group::AboTourenPortal.sti_name, parent: groups(:abonnenten)).tap do |group|
+    Fabricate.build(Group::AboTourenPortal.sti_name, parent: groups(:abos)).tap do |group|
       group.self_registration_role_type = Group::AboTourenPortal::Abonnent.sti_name
     end
   end


### PR DESCRIPTION
Beim Review:

- [ ] Seeds neu laden

Nach dem Review:

- [ ] Auf der Integrationsumgebung folgende Gruppen löschen:
```ruby
Group.where(type: "Group::Abonnenten").each { |group| group.children.each(&:really_destroy!) }
Group.where(type: "Group::Abonnenten").each { |group| group.really_destroy! }
Group.where(type: "Group::AboTourenPortal").each { |group| group.really_destroy! }
Group.where(type: "Group::AboBasicLogin").each { |group| group.really_destroy! }
```

Nach dem Merge:

- [ ] In #hitobito-developers informieren: "Aufgrund von https://github.com/hitobito/hitobito_sac_cas/pull/806 bitte nicht vergessen lokale Datenbank löschen und neu seeden."
- [ ] SAC via Stefan informieren, dass die Struktur verändert wurde, bzw. das Ticket umgesetzt ist.