### PR TITLE
EVENTS: E-Mail Kursveröffentlichung Empfänger fix

### DIFF
--- a/app/jobs/event/leader_reminder_job.rb
+++ b/app/jobs/event/leader_reminder_job.rb
@@ -16,12 +16,18 @@ class Event::LeaderReminderJob < RecurringJob
   end
 
   def send_reminder(start_at, content_key)
+    events_starting_at(start_at).each do |course|
+      course.leaders.each do |leader|
+        Event::LeaderReminderMailer.reminder(course, content_key, leader).deliver_now
+      end
+    end
+  end
+
+  def events_starting_at(start_at)
     Event::Course.joins(:dates)
       .where(event_dates: {start_at: start_at.all_day})
       .where.not(contact: nil)
-      .uniq.each do |course|
-      Event::LeaderReminderMailer.reminder(course, content_key).deliver_now
-    end
+      .uniq
   end
 
   def next_run

--- a/app/jobs/event/leader_reminder_job.rb
+++ b/app/jobs/event/leader_reminder_job.rb
@@ -24,10 +24,7 @@ class Event::LeaderReminderJob < RecurringJob
   end
 
   def events_starting_at(start_at)
-    Event::Course.joins(:dates)
-      .where(event_dates: {start_at: start_at.all_day})
-      .where.not(contact: nil)
-      .uniq
+    Event::Course.joins(:dates).where(event_dates: {start_at: start_at.all_day}).uniq
   end
 
   def next_run

--- a/app/jobs/event/published_job.rb
+++ b/app/jobs/event/published_job.rb
@@ -6,20 +6,25 @@
 #  https://github.com/hitobito/hitobito_sac_cas.
 
 class Event::PublishedJob < BaseJob
-  self.parameters = [:course_id]
+  self.parameters = %i[course_id leader_id]
 
-  def initialize(course)
+  def initialize(course, leader)
     super()
     @course_id = course.id
+    @leader_id = leader.id
   end
 
   def perform
     return unless course # may have been deleted again
 
-    Event::PublishedMailer.notice(course).deliver_now
+    Event::PublishedMailer.notice(course, leader).deliver_now
   end
 
   def course
     @course ||= Event::Course.find_by(id: @course_id)
+  end
+
+  def leader
+    @leader ||= Person.find_by(id: @leader_id)
   end
 end

--- a/app/mailers/event/leader_reminder_mailer.rb
+++ b/app/mailers/event/leader_reminder_mailer.rb
@@ -11,11 +11,11 @@ class Event::LeaderReminderMailer < ApplicationMailer
   REMINDER_NEXT_WEEK = "event_leader_reminder_next_week"
   REMINDER_8_WEEKS = "event_leader_reminder_8_weeks"
 
-  def reminder(course, content_key)
+  def reminder(course, content_key, leader)
     @course = course
     headers = {bcc: course.groups.first.course_admin_email}
     locales = course.language.split("_")
 
-    compose(course.contact, content_key, headers, locales)
+    compose(leader, content_key, headers, locales)
   end
 end

--- a/app/mailers/event/leader_reminder_mailer.rb
+++ b/app/mailers/event/leader_reminder_mailer.rb
@@ -13,9 +13,14 @@ class Event::LeaderReminderMailer < ApplicationMailer
 
   def reminder(course, content_key, leader)
     @course = course
+    @leader = leader
     headers = {bcc: course.groups.first.course_admin_email}
     locales = course.language.split("_")
 
     compose(leader, content_key, headers, locales)
+  end
+
+  def placeholder_recipient_name
+    @leader.greeting_name
   end
 end

--- a/app/mailers/event/published_mailer.rb
+++ b/app/mailers/event/published_mailer.rb
@@ -11,13 +11,18 @@ class Event::PublishedMailer < ApplicationMailer
   EVENT_LEADER_ROLES = [Event::Role::Leader, Event::Role::AssistantLeader].map(&:sti_name)
   NOTICE = "event_published_notice"
 
-  def notice(course)
+  def notice(course, leader)
     @course = course
+    @leader = leader
     headers = {bcc: course.groups.first.course_admin_email}
     locales = course.language.split("_")
-    event_leaders = Person.where(id: course.participations.joins(:roles)
-      .where(roles: {type: EVENT_LEADER_ROLES}).pluck(:person_id))
 
-    compose(event_leaders, NOTICE, headers, locales)
+    compose(leader, NOTICE, headers, locales)
+  end
+
+  private
+
+  def placeholder_recipient_name
+    @leader.greeting_name
   end
 end

--- a/app/models/sac_cas/event/course.rb
+++ b/app/models/sac_cas/event/course.rb
@@ -176,6 +176,11 @@ module SacCas::Event::Course
     super
   end
 
+  def leaders
+    Person.where(id: participations.joins(:roles)
+      .where(roles: {type: LEADER_ROLES}).pluck(:person_id))
+  end
+
   private
 
   def weak_validation_state?
@@ -197,10 +202,7 @@ module SacCas::Event::Course
   end
 
   def send_application_published_email
-    Person
-      .where(id: participations.joins(:roles)
-      .where(roles: {type: LEADER_ROLES})
-      .pluck(:person_id)).find_each do |leader|
+    leaders.each do |leader|
       Event::PublishedJob.new(self, leader).enqueue!
     end
   end

--- a/spec/models/event/course_spec.rb
+++ b/spec/models/event/course_spec.rb
@@ -356,7 +356,7 @@ describe Event::Course do
   end
 
   describe "when state changes to application_open" do
-    subject(:course) { Fabricate(:sac_open_course, contact_id: people(:admin).id) }
+    let(:course) { Fabricate(:sac_open_course, contact_id: people(:admin).id) }
 
     before { course.groups.first.update!(course_admin_email: "admin@example.com") }
 
@@ -426,7 +426,7 @@ describe Event::Course do
   end
 
   describe "when state changes to application_paused" do
-    subject(:course) { Fabricate(:sac_open_course, language: "fr") }
+    let(:course) { Fabricate(:sac_open_course, language: "fr") }
 
     context "with course admin" do
       before { course.groups.first.update!(course_admin_email: "admin@example.com") }


### PR DESCRIPTION
Fixes #599 (#804)
Fixes #629
Fixes #634

alle fixes sind das gleiche: `course.contact` -> `leaders`
sendet jede mail einzeln mit dem richtigen empfänger
siehe #765 zur testanleitung oder `kurs -> entwurf -> publizieren`