### PR TITLE
PEOPLE: Stammsektionwechsel nur per sofort erlauben (2/2)

### DIFF
--- a/app/models/memberships/join_base.rb
+++ b/app/models/memberships/join_base.rb
@@ -17,10 +17,9 @@ module Memberships
     validate :assert_person_not_member_of_join_section
     validate :assert_family_main_person, if: :validate_family_main_person?
 
-    def initialize(join_section, person, join_date, **params)
+    def initialize(join_section, person, **params)
       @join_section = join_section
       @person = person
-      @join_date = join_date
       @now = Time.zone.now
 
       assert_sac_section_or_ortsgruppe!
@@ -64,6 +63,6 @@ module Memberships
       People::SacMembership.new(person)
     end
 
-    attr_reader :person, :join_section, :join_date, :now
+    attr_reader :person, :join_section, :now
   end
 end

--- a/app/models/memberships/join_zusatzsektion.rb
+++ b/app/models/memberships/join_zusatzsektion.rb
@@ -11,8 +11,8 @@ module Memberships
 
     attr_reader :person
 
-    def initialize(join_section, person, join_date, sac_family_membership: false, **params)
-      super(join_section, person, join_date, **params)
+    def initialize(join_section, person, sac_family_membership: false, **params)
+      super(join_section, person, **params)
       @sac_family_membership = sac_family_membership
 
       raise "missing neuanmeldungen subgroup" unless group_for_neuanmeldung

--- a/app/models/memberships/switch_stammsektion.rb
+++ b/app/models/memberships/switch_stammsektion.rb
@@ -12,8 +12,6 @@ module Memberships
       raise "terminated membership" if sac_membership.stammsektion_role&.terminated?
     end
 
-    validate :assert_join_date
-
     def save
       super.tap do |success|
         update_primary_groups
@@ -65,10 +63,6 @@ module Memberships
 
     def validate_family_main_person?
       person.sac_membership.family?
-    end
-
-    def assert_join_date
-      errors.add(:join_date, :invalid) unless join_date == now.to_date
     end
 
     def membership_group

--- a/app/models/wizards/memberships/join_zusatzsektion.rb
+++ b/app/models/wizards/memberships/join_zusatzsektion.rb
@@ -42,7 +42,6 @@ module Wizards::Memberships
         Memberships::JoinZusatzsektion.new(
           choose_sektion.group,
           person,
-          Time.zone.today,
           sac_family_membership: family_membership?
         )
     end

--- a/app/models/wizards/memberships/switch_stammsektion.rb
+++ b/app/models/wizards/memberships/switch_stammsektion.rb
@@ -35,12 +35,7 @@ module Wizards::Memberships
     end
 
     def switch_operation
-      @switch_operation ||=
-        Memberships::SwitchStammsektion.new(
-          choose_sektion.group,
-          person,
-          Time.zone.today
-        )
+      @switch_operation ||= Memberships::SwitchStammsektion.new(choose_sektion.group, person)
     end
 
     def backoffice?

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -56,8 +56,6 @@ de:
         myself: für mich selbst
       wizards/steps/switch_stammsektion:
         now: sofort
-      memberships/join_base:
-        join_date: Beitrittsdatum
       memberships/leave_zusatzsektion:
         terminate_on: Austrittsdatum
       people/neuanmeldungen/reject:

--- a/spec/models/memberships/join_base_spec.rb
+++ b/spec/models/memberships/join_base_spec.rb
@@ -16,15 +16,15 @@ describe Memberships::JoinBase do
 
   it "initialization fails on invalid group" do
     expect do
-      described_class.new(Group::Sektion.new, :person, :date)
+      described_class.new(Group::Sektion.new, :person)
     end.not_to raise_error
 
     expect do
-      described_class.new(Group::Ortsgruppe.new, :person, :date)
+      described_class.new(Group::Ortsgruppe.new, :person)
     end.not_to raise_error
 
     expect do
-      described_class.new(Group::SacCas.new, :person, :date)
+      described_class.new(Group::SacCas.new, :person)
     end.to raise_error("must be section/ortsgruppe")
   end
 
@@ -32,9 +32,8 @@ describe Memberships::JoinBase do
     let(:person) { Fabricate(:person) }
     let(:join_section) { groups(:bluemlisalp) }
     let(:errors) { obj.errors.full_messages }
-    let(:date) { Date.new(2024, 6, 14) }
 
-    subject(:obj) { described_class.new(join_section, person, date) }
+    subject(:obj) { described_class.new(join_section, person) }
 
     it "is invalid if person is not an sac member" do
       expect(obj).not_to be_valid
@@ -132,9 +131,8 @@ describe Memberships::JoinBase do
     let(:person) { Fabricate(:person) }
     let(:group) { groups(:matterhorn) }
     let(:errors) { obj.errors.full_messages }
-    let(:date) { Date.new(2024, 6, 14) }
 
-    subject(:obj) { described_class.new(group, person, date) }
+    subject(:obj) { described_class.new(group, person) }
 
     context "invalid" do
       it "save returns false and populates errors" do

--- a/spec/models/memberships/join_base_spec.rb
+++ b/spec/models/memberships/join_base_spec.rb
@@ -15,13 +15,8 @@ describe Memberships::JoinBase do
   end
 
   it "initialization fails on invalid group" do
-    expect do
-      described_class.new(Group::Sektion.new, :person)
-    end.not_to raise_error
-
-    expect do
-      described_class.new(Group::Ortsgruppe.new, :person)
-    end.not_to raise_error
+    expect { described_class.new(Group::Sektion.new, :person) }.not_to raise_error
+    expect { described_class.new(Group::Ortsgruppe.new, :person) }.not_to raise_error
 
     expect do
       described_class.new(Group::SacCas.new, :person)

--- a/spec/models/memberships/join_zusatzsektion_spec.rb
+++ b/spec/models/memberships/join_zusatzsektion_spec.rb
@@ -16,19 +16,19 @@ describe Memberships::JoinZusatzsektion do
 
   it "initialization fails if no neuanmeldungen subgroup exists" do
     expect do
-      described_class.new(Group::Sektion.new, :person, :date)
+      described_class.new(Group::Sektion.new, :person)
     end.to raise_error("missing neuanmeldungen subgroup")
 
     expect do
-      described_class.new(Group::Ortsgruppe.new, :person, :date)
+      described_class.new(Group::Ortsgruppe.new, :person)
     end.to raise_error("missing neuanmeldungen subgroup")
 
     expect do
-      described_class.new(groups(:bluemlisalp), :person, :date)
+      described_class.new(groups(:bluemlisalp), :person)
     end.not_to raise_error
 
     expect do
-      described_class.new(groups(:bluemlisalp_ortsgruppe_ausserberg), :person, :date)
+      described_class.new(groups(:bluemlisalp_ortsgruppe_ausserberg), :person)
     end.not_to raise_error
   end
 
@@ -36,9 +36,8 @@ describe Memberships::JoinZusatzsektion do
     let(:person) { Fabricate(:person) }
     let(:join_section) { groups(:bluemlisalp) }
     let(:errors) { join_sektion.errors.full_messages }
-    let(:date) { Date.new(2024, 6, 14) }
 
-    subject(:join_sektion) { described_class.new(join_section, person, date) }
+    subject(:join_sektion) { described_class.new(join_section, person) }
 
     it "is invalid if person is not an sac member" do
       expect(join_sektion).not_to be_valid
@@ -124,11 +123,10 @@ describe Memberships::JoinZusatzsektion do
     let(:person) { Fabricate(:person) }
     let(:sektion) { groups(:matterhorn) }
     let(:errors) { join_sektion.errors.full_messages }
-    let(:date) { Date.new(2024, 6, 14) }
 
     let(:role) { (person.roles - [mitglied]).first }
 
-    subject(:join_sektion) { described_class.new(sektion, person, date) }
+    subject(:join_sektion) { described_class.new(sektion, person) }
 
     context "invalid" do
       it "save returns false and populates errors" do
@@ -223,7 +221,7 @@ describe Memberships::JoinZusatzsektion do
 
       context "without providing sac_family_membership flag is passed as true" do
         subject(:join_sektion) do
-          described_class.new(sektion, person, date, sac_family_membership: true)
+          described_class.new(sektion, person, sac_family_membership: true)
         end
 
         it "creates roles with family category for both people" do

--- a/spec/models/memberships/switch_stammsektion_spec.rb
+++ b/spec/models/memberships/switch_stammsektion_spec.rb
@@ -21,19 +21,19 @@ describe Memberships::SwitchStammsektion do
   it "initialization fails on invalid group" do
     person = Fabricate(:person)
     expect do
-      described_class.new(Group::Sektion.new, person, :join_date)
+      described_class.new(Group::Sektion.new, person)
     end.not_to raise_error
 
     expect do
-      described_class.new(Group::Ortsgruppe.new, person, :join_date)
+      described_class.new(Group::Ortsgruppe.new, person)
     end.not_to raise_error
 
     expect do
-      described_class.new(Group::SacCas.new, person, :join_date)
+      described_class.new(Group::SacCas.new, person)
     end.to raise_error("must be section/ortsgruppe")
   end
 
-  subject(:switch) { described_class.new(join_section, person, now.to_date) }
+  subject(:switch) { described_class.new(join_section, person) }
 
   describe "validations" do
     let(:person) { Fabricate(:person) }
@@ -48,17 +48,6 @@ describe Memberships::SwitchStammsektion do
     it "is valid with membership in different section" do
       create_role(:matterhorn_mitglieder, "Mitglied", created_at: 1.year.ago)
       expect(switch).to be_valid
-    end
-
-    describe "join_date" do
-      def switch_on(join_date) = described_class.new(join_section, person, join_date)
-
-      it "is valid today" do
-        create_role(:matterhorn_mitglieder, "Mitglied", created_at: 1.year.ago)
-        expect(switch_on(now.to_date)).to be_valid
-        expect(switch_on(now)).not_to be_valid
-        expect(switch_on(now.next_year.beginning_of_year.to_date)).not_to be_valid
-      end
     end
 
     describe "existing membership in tree" do
@@ -90,7 +79,7 @@ describe Memberships::SwitchStammsektion do
     let(:group) { groups(:matterhorn) }
     let(:errors) { switch.errors.full_messages }
 
-    subject(:switch) { described_class.new(group, person, now.to_date) }
+    subject(:switch) { described_class.new(group, person) }
 
     context "invalid" do
       it "save returns false and populates errors" do
@@ -156,7 +145,7 @@ describe Memberships::SwitchStammsektion do
       end
 
       it "is invalid if switch is attempted with person that is not a sac_family_main_person" do
-        switch = described_class.new(group, other, now)
+        switch = described_class.new(group, other)
         expect(switch).not_to be_valid
         expect(switch.errors.full_messages).to include("Person muss Hauptperson der Familie sein")
       end


### PR DESCRIPTION
Reviewed im #811, ging bei force push verloren