### PR TITLE
Send daily qualification expiration mails for integration testing

### DIFF
--- a/app/domain/qualifications/expiring.rb
+++ b/app/domain/qualifications/expiring.rb
@@ -8,7 +8,7 @@
 class Qualifications::Expiring
   class << self
     def entries(finish_at)
-      Qualification.where(finish_at: finish_at).joins(latest_expirations_join).includes(:person)
+      Qualification.where(finish_at: finish_at).joins(latest_expirations_join)
     end
 
     private

--- a/app/mailers/qualifications/expiration_mailer.rb
+++ b/app/mailers/qualifications/expiration_mailer.rb
@@ -11,10 +11,10 @@ class Qualifications::ExpirationMailer < ApplicationMailer
   REMINDER_NEXT_YEAR = "qualification_expiration_reminder_next_year"
   REMINDER_YEAR_AFTER_NEXT_YEAR = "qualification_expiration_reminder_year_after_next_year"
 
-  def reminder(moment, person)
+  def reminder(moment, person_id)
     return unless MOMENTS.include?(moment)
 
-    compose(person, content_key(moment))
+    compose(Person.find(person_id), content_key(moment))
   end
 
   private


### PR DESCRIPTION
refs #260

Da die einen Mails nur am 31.12. verschickt werden, kann dieses Feature kaum getestet werden. Deshalb werden temporär täglich alle E-Mails verschickt. Sobald das Ticket abgenommen ist, wird der entsprechende Kommentar wieder entfernt. (Nicht aber die anderen Changes ;)