### PR TITLE
Improve calculation membership years (#835)

### DIFF
--- a/app/models/sac_cas/role.rb
+++ b/app/models/sac_cas/role.rb
@@ -66,9 +66,9 @@ module SacCas::Role
                             ) YEAR
                           )
                         )
-                      ) / 365.25 -- .25 to calculate for leap years
+                      ) / 365.25
                     )
-                      END
+              END
           )
         END AS membership_years
       SQL

--- a/app/models/sac_cas/role.rb
+++ b/app/models/sac_cas/role.rb
@@ -6,7 +6,7 @@
 #  https://github.com/hitobito/hitobito_sac_cas.
 
 module SacCas::Role
-  module ClassMethods   
+  module ClassMethods
     def select_with_membership_years(date = Time.zone.today)
       # Because the parameter passed in the query is CET, we make sure to convert all database dates from UTC to CET.
       <<~SQL
@@ -38,7 +38,7 @@ module SacCas::Role
         END AS membership_years
       SQL
     end
-    
+
     def calculate_least_date(date)
       <<~SQL
         LEAST(
@@ -48,7 +48,7 @@ module SacCas::Role
           COALESCE(roles.delete_on::date + INTERVAL '1 day', '9999-12-31')
         )
       SQL
-    end    
+    end
   end
 
   def self.prepended(base)

--- a/spec/domain/invoices/sac_memberships/member_spec.rb
+++ b/spec/domain/invoices/sac_memberships/member_spec.rb
@@ -45,7 +45,7 @@ describe Invoices::SacMemberships::Member do
 
     it "is off by one in first year" do
       roles(:mitglied).update_column(:created_at, date)
-      expect(subject.membership_years).to eq(1)
+      expect(subject.membership_years).to eq(2)
     end
   end
 

--- a/spec/domain/invoices/sac_memberships/member_spec.rb
+++ b/spec/domain/invoices/sac_memberships/member_spec.rb
@@ -39,13 +39,23 @@ describe Invoices::SacMemberships::Member do
     let(:person) { context.people_with_membership_years.find(people(:mitglied).id) }
 
     it "counts years correctly" do
-      roles(:mitglied).update_column(:created_at, "2015-01-20")
-      expect(subject.membership_years).to eq(9)
+      roles(:mitglied).update_column(:created_at, "2015-01-01")
+      expect(subject.membership_years).to eq(8)
     end
 
     it "is off by one in first year" do
       roles(:mitglied).update_column(:created_at, date)
-      expect(subject.membership_years).to eq(2)
+      expect(subject.membership_years).to eq(0)
+    end
+
+    it "counts years correctly in second year" do
+      roles(:mitglied).update_column(:created_at, "2023-01-01")
+      expect(subject.membership_years).to eq(0)
+    end
+
+    it "counts years correctly in third year" do
+      roles(:mitglied).update_column(:created_at, "2022-01-01")
+      expect(subject.membership_years).to eq(1)
     end
   end
 

--- a/spec/domain/invoices/sac_memberships/member_spec.rb
+++ b/spec/domain/invoices/sac_memberships/member_spec.rb
@@ -40,7 +40,7 @@ describe Invoices::SacMemberships::Member do
 
     it "counts years correctly" do
       roles(:mitglied).update_column(:created_at, "2015-01-20")
-      expect(subject.membership_years).to eq(8)
+      expect(subject.membership_years).to eq(9)
     end
 
     it "is off by one in first year" do

--- a/spec/domain/invoices/sac_memberships/position_generator_spec.rb
+++ b/spec/domain/invoices/sac_memberships/position_generator_spec.rb
@@ -623,7 +623,7 @@ describe Invoices::SacMemberships::PositionGenerator do
 
     context "last year without reduction" do
       before do
-        roles(:mitglied).update!(created_at: date.year - 24)
+        roles(:mitglied).update!(created_at: date - 24.years)
       end
 
       it "generates positions without reduction" do

--- a/spec/domain/invoices/sac_memberships/position_generator_spec.rb
+++ b/spec/domain/invoices/sac_memberships/position_generator_spec.rb
@@ -623,7 +623,7 @@ describe Invoices::SacMemberships::PositionGenerator do
 
     context "last year without reduction" do
       before do
-        roles(:mitglied).update!(created_at: date - 24.years)
+        roles(:mitglied).update!(created_at: Date.new(date.year - 24, 12, 31))
       end
 
       it "generates positions without reduction" do

--- a/spec/domain/invoices/sac_memberships/position_generator_spec.rb
+++ b/spec/domain/invoices/sac_memberships/position_generator_spec.rb
@@ -623,9 +623,7 @@ describe Invoices::SacMemberships::PositionGenerator do
 
     context "last year without reduction" do
       before do
-        # because days are divided by 365, people with an entry date before january 9th
-        # will have 25 years already one year earlier
-        roles(:mitglied).update!(created_at: Date.new(date.year - 24, 1, 9))
+        roles(:mitglied).update!(created_at: date.year - 24)
       end
 
       it "generates positions without reduction" do

--- a/spec/domain/invoices/sac_memberships/position_generator_spec.rb
+++ b/spec/domain/invoices/sac_memberships/position_generator_spec.rb
@@ -623,7 +623,7 @@ describe Invoices::SacMemberships::PositionGenerator do
 
     context "last year without reduction" do
       before do
-        roles(:mitglied).update!(created_at: Date.new(date.year - 24, 12, 31))
+        roles(:mitglied).update!(created_at: Date.new(date.year - 24, 1, 1))
       end
 
       it "generates positions without reduction" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -90,59 +90,20 @@ describe Person do
       expect(person_with_membership_years.membership_years).to eq 2
     end
 
-    it "rounds down to full years" do
+    it 'calculates membership years correctly for the next 20 years' do
       role = create_role(delete_on: created_at + 363.days)
       expect(person_with_membership_years.membership_years).to eq 0
 
-      role.update(delete_on: created_at + 1.years)
-      expect(person_with_membership_years.membership_years).to eq 1
-
-      role.update(delete_on: created_at + 2.years - 1.days)
-      expect(person_with_membership_years.membership_years).to eq 1
-
-      role.update(delete_on: created_at + 2.years)
-      expect(person_with_membership_years.membership_years).to eq 2
-
-      role.update(delete_on: created_at + 3.years - 1.days)
-      expect(person_with_membership_years.membership_years).to eq 2
-
-      role.update(delete_on: created_at + 3.years)
-      expect(person_with_membership_years.membership_years).to eq 3
-
-      role.update(delete_on: created_at + 4.years - 1.days)
-      expect(person_with_membership_years.membership_years).to eq 3
-
-      role.update(delete_on: created_at + 4.years)
-      expect(person_with_membership_years.membership_years).to eq 4
-
-      role.update(delete_on: created_at + 5.years - 1.days)
-      expect(person_with_membership_years.membership_years).to eq 4
-
-      role.update(delete_on: created_at + 5.years)
-      expect(person_with_membership_years.membership_years).to eq 5
-
-      role.update(delete_on: created_at + 20.years - 1.days)
-      expect(person_with_membership_years.membership_years).to eq 19
-
-      # 2000 was a leap year (role date is 31.12.2000 in this test case)
-      role.update(delete_on: created_at + 365.days)
-      expect(person_with_membership_years.membership_years).to eq 0
-
-      # 2000 was a leap year (role date is 01.01.2001 in this test case)
-      role.update(delete_on: created_at + 366.days)
-      expect(person_with_membership_years.membership_years).to eq 1
-
-      # 2004 was a leap year (role date is 31.12.2004 in this test case)
-      role.update(delete_on: created_at + 1826.days)
-      expect(person_with_membership_years.membership_years).to eq 4
-
-      # 2004 was a leap year (role date is 01.01.2005 in this test case)
-      role.update(delete_on: created_at + 1827.days)
-      expect(person_with_membership_years.membership_years).to eq 5
-
-      # check membership duration when role was created in the end of year and delete on is in less than one year
-      role.update(created_at: Date.new(2000, 12, 31), delete_on: Date.new(2001, 06, 06))
-      expect(person_with_membership_years.membership_years).to eq 0
+      (1..20).each do |x|
+        [
+          { years_offset: x.years - 2.days, expected_years: x - 1 },
+          { years_offset: x.years - 1.days, expected_years: x },
+          { years_offset: x.years, expected_years: x }
+        ].each do |test_case|
+          role.update(delete_on: role.created_at + test_case[:years_offset])
+          expect(person_with_membership_years.membership_years).to eq(test_case[:expected_years])
+        end
+      end
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -105,6 +105,18 @@ describe Person do
         end
       end
     end
+
+    it "calculates membership years from roles starting and ending in overlaping years" do
+      role = create_role(delete_on: created_at + 200.days)
+      role.update!(created_at: created_at + 100.days)
+      expect(person_with_membership_years.membership_years).to eq 0
+
+      role.update(delete_on: created_at + 565.days)
+      expect(person_with_membership_years.membership_years).to eq(1)
+
+      role.update(delete_on: created_at + 930.days)
+      expect(person_with_membership_years.membership_years).to eq(2)
+    end
   end
 
   describe "#salutation_label" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -86,7 +86,15 @@ describe Person do
 
     it "with multiple membership roles returns the sum of role.membership_years" do
       create_role(created_at: created_at, delete_on: created_at + 1.years)
-      create_role(created_at: created_at + 2.years, delete_on: created_at + 2.years + 365.days)
+      create_role(created_at: created_at + 2.years, delete_on: created_at + 3.years)
+      expect(person_with_membership_years.membership_years).to eq 2
+    end
+
+    it "multiple roles, with duration of less than a year, add together to membership_years" do
+      create_role(created_at: Date.new(2000, 1, 1), delete_on: Date.new(2000, 7, 1))
+      create_role(created_at: Date.new(2000, 7, 2), delete_on: Date.new(2001, 1, 1))
+      create_role(created_at: Date.new(2001, 1, 2), delete_on: Date.new(2001, 7, 1))
+      create_role(created_at: Date.new(2001, 7, 2), delete_on: Date.new(2002, 1, 1))
       expect(person_with_membership_years.membership_years).to eq 2
     end
 
@@ -107,14 +115,14 @@ describe Person do
     end
 
     it "calculates membership years from roles starting and ending in overlaping years" do
-      role = create_role(delete_on: created_at + 200.days)
-      role.update!(created_at: created_at + 100.days)
+      role = create_role(delete_on: Date.new(2000, 0o7, 19))
+      role.update!(created_at: Date.new(2000, 0o4, 10))
       expect(person_with_membership_years.membership_years).to eq 0
 
-      role.update(delete_on: created_at + 565.days)
+      role.update(delete_on: Date.new(2001, 0o7, 19))
       expect(person_with_membership_years.membership_years).to eq(1)
 
-      role.update(delete_on: created_at + 930.days)
+      role.update(delete_on: Date.new(2002, 0o7, 19))
       expect(person_with_membership_years.membership_years).to eq(2)
     end
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -98,6 +98,28 @@ describe Person do
       expect(person_with_membership_years.membership_years).to eq 2
     end
 
+    it "calculates membership years correctly for leap year" do
+      create_role(created_at: Date.new(2020, 1, 1), delete_on: Date.new(2020, 12, 31))
+      expect(person_with_membership_years.membership_years).to eq 1
+    end
+
+    it "calculates membership years correctly for leap year when passing reporting date" do
+      create_role(created_at: Date.new(2020, 1, 1), delete_on: Date.new(2023, 12, 31))
+      expect(Person.with_membership_years("people.*", Date.new(2020, 12, 31)).find(person.id).membership_years).to eq(0)
+      expect(Person.with_membership_years("people.*", Date.new(2020, 1, 1)).find(person.id).membership_years).to eq(1)
+    end
+
+    it "calculates membership years correctly for two years with one leap year" do
+      create_role(created_at: Date.new(2020, 1, 1), delete_on: Date.new(2021, 12, 31))
+      expect(person_with_membership_years.membership_years).to eq 2
+    end
+
+    it "calculates membership years correctly for two years with one leap year when passing reporting date" do
+      create_role(created_at: Date.new(2020, 1, 1), delete_on: Date.new(2023, 12, 31))
+      expect(Person.with_membership_years("people.*", Date.new(2021, 12, 31)).find(person.id).membership_years).to eq(1)
+      expect(Person.with_membership_years("people.*", Date.new(2022, 1, 1)).find(person.id).membership_years).to eq(2)
+    end
+
     it "calculates membership years correctly for the next 20 years" do
       role = create_role(delete_on: created_at + 363.days)
       expect(person_with_membership_years.membership_years).to eq 0
@@ -112,6 +134,12 @@ describe Person do
           expect(person_with_membership_years.membership_years).to eq(test_case[:expected_years])
         end
       end
+    end
+
+    it "calculates membership years correctly when passing reporting date" do
+      role = create_role(delete_on: created_at + 5.years)
+      expect(Person.with_membership_years("people.*", Date.new(2001, 12, 31)).find(person.id).membership_years).to eq(1)
+      expect(Person.with_membership_years("people.*", Date.new(2002, 1, 1)).find(person.id).membership_years).to eq(2)
     end
 
     it "calculates membership years from roles starting and ending in overlaping years" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -45,7 +45,7 @@ describe Person do
     let(:person) { Fabricate(:person, birthday: Date.parse("01-01-1985")) }
 
     let(:created_at) { Time.zone.parse("01-01-2000 12:00:00") }
-    let(:end_at) { created_at + 364.days }
+    let(:end_at) { created_at + 1.years }
 
     def person_with_membership_years
       Person.with_membership_years.find(person.id)
@@ -85,7 +85,7 @@ describe Person do
     end
 
     it "with multiple membership roles returns the sum of role.membership_years" do
-      create_role(created_at: created_at, delete_on: created_at + 365.days)
+      create_role(created_at: created_at, delete_on: created_at + 1.years)
       create_role(created_at: created_at + 2.years, delete_on: created_at + 2.years + 365.days)
       expect(person_with_membership_years.membership_years).to eq 2
     end
@@ -94,21 +94,55 @@ describe Person do
       role = create_role(delete_on: created_at + 363.days)
       expect(person_with_membership_years.membership_years).to eq 0
 
-      role.update(delete_on: created_at + 364.days)
+      role.update(delete_on: created_at + 1.years)
       expect(person_with_membership_years.membership_years).to eq 1
 
-      role.update(delete_on: created_at + 728.days)
+      role.update(delete_on: created_at + 2.years - 1.days)
       expect(person_with_membership_years.membership_years).to eq 1
 
-      role.update(delete_on: created_at + 729.days)
+      role.update(delete_on: created_at + 2.years)
       expect(person_with_membership_years.membership_years).to eq 2
 
-      role.update(delete_on: created_at + 20.years)
-      expect(person_with_membership_years.membership_years).to eq 20
+      role.update(delete_on: created_at + 3.years - 1.days)
+      expect(person_with_membership_years.membership_years).to eq 2
 
-      # currently failing
-      # role.update(delete_on: created_at + 20.years - 2.days)
-      # expect(person_with_membership_years.membership_years).to eq 19
+      role.update(delete_on: created_at + 3.years)
+      expect(person_with_membership_years.membership_years).to eq 3
+
+      role.update(delete_on: created_at + 4.years - 1.days)
+      expect(person_with_membership_years.membership_years).to eq 3
+
+      role.update(delete_on: created_at + 4.years)
+      expect(person_with_membership_years.membership_years).to eq 4
+
+      role.update(delete_on: created_at + 5.years - 1.days)
+      expect(person_with_membership_years.membership_years).to eq 4
+
+      role.update(delete_on: created_at + 5.years)
+      expect(person_with_membership_years.membership_years).to eq 5
+
+      role.update(delete_on: created_at + 20.years - 1.days)
+      expect(person_with_membership_years.membership_years).to eq 19
+
+      # 2000 was a leap year (role date is 31.12.2000 in this test case)
+      role.update(delete_on: created_at + 365.days)
+      expect(person_with_membership_years.membership_years).to eq 0
+
+      # 2000 was a leap year (role date is 01.01.2001 in this test case)
+      role.update(delete_on: created_at + 366.days)
+      expect(person_with_membership_years.membership_years).to eq 1
+
+      # 2004 was a leap year (role date is 31.12.2004 in this test case)
+      role.update(delete_on: created_at + 1826.days)
+      expect(person_with_membership_years.membership_years).to eq 4
+
+      # 2004 was a leap year (role date is 01.01.2005 in this test case)
+      role.update(delete_on: created_at + 1827.days)
+      expect(person_with_membership_years.membership_years).to eq 5
+
+      # check membership duration when role was created in the end of year and delete on is in less than one year
+      role.update(created_at: Date.new(2000, 12, 31), delete_on: Date.new(2001, 06, 06))
+      expect(person_with_membership_years.membership_years).to eq 0
     end
   end
 

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -95,6 +95,7 @@ describe Person do
       create_role(created_at: Date.new(2000, 7, 2), delete_on: Date.new(2001, 1, 1))
       create_role(created_at: Date.new(2001, 1, 2), delete_on: Date.new(2001, 7, 1))
       create_role(created_at: Date.new(2001, 7, 2), delete_on: Date.new(2002, 1, 1))
+      create_role(created_at: Date.new(2002, 1, 2), delete_on: Date.new(2002, 7, 1))
       expect(person_with_membership_years.membership_years).to eq 2
     end
 
@@ -106,7 +107,7 @@ describe Person do
     it "calculates membership years correctly for leap year when passing reporting date" do
       create_role(created_at: Date.new(2020, 1, 1), delete_on: Date.new(2023, 12, 31))
       expect(Person.with_membership_years("people.*", Date.new(2020, 12, 31)).find(person.id).membership_years).to eq(0)
-      expect(Person.with_membership_years("people.*", Date.new(2020, 1, 1)).find(person.id).membership_years).to eq(1)
+      expect(Person.with_membership_years("people.*", Date.new(2021, 1, 1)).find(person.id).membership_years).to eq(1)
     end
 
     it "calculates membership years correctly for two years with one leap year" do
@@ -137,12 +138,12 @@ describe Person do
     end
 
     it "calculates membership years correctly when passing reporting date" do
-      role = create_role(delete_on: created_at + 5.years)
+      create_role(delete_on: created_at + 5.years)
       expect(Person.with_membership_years("people.*", Date.new(2001, 12, 31)).find(person.id).membership_years).to eq(1)
       expect(Person.with_membership_years("people.*", Date.new(2002, 1, 1)).find(person.id).membership_years).to eq(2)
     end
 
-    it "calculates membership years from roles starting and ending in overlaping years" do
+    it "calculates membership years from roles starting and ending in overlapping years" do
       role = create_role(delete_on: Date.new(2000, 0o7, 19))
       role.update!(created_at: Date.new(2000, 0o4, 10))
       expect(person_with_membership_years.membership_years).to eq 0

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -90,15 +90,15 @@ describe Person do
       expect(person_with_membership_years.membership_years).to eq 2
     end
 
-    it 'calculates membership years correctly for the next 20 years' do
+    it "calculates membership years correctly for the next 20 years" do
       role = create_role(delete_on: created_at + 363.days)
       expect(person_with_membership_years.membership_years).to eq 0
 
       (1..20).each do |x|
         [
-          { years_offset: x.years - 2.days, expected_years: x - 1 },
-          { years_offset: x.years - 1.days, expected_years: x },
-          { years_offset: x.years, expected_years: x }
+          {years_offset: x.years - 2.days, expected_years: x - 1},
+          {years_offset: x.years - 1.days, expected_years: x},
+          {years_offset: x.years, expected_years: x}
         ].each do |test_case|
           role.update(delete_on: role.created_at + test_case[:years_offset])
           expect(person_with_membership_years.membership_years).to eq(test_case[:expected_years])

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -386,7 +386,7 @@ describe Role do
   context "#membership_years" do
     let(:created_at) { Time.zone.parse("01-01-2000 12:00:00") }
     let(:end_at) { created_at + 7.years + 6.months }
-    let(:years) { 7.5 }
+    let(:years) { 7 }
 
     def create_role(**attrs)
       Fabricate(Group::SektionsMitglieder::Mitglied.name,

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -446,7 +446,7 @@ describe Role do
     it "calculates value and does not include last day for date today" do
       create_role(created_at: 1.year.ago + 1.days, delete_on: 2.years.from_now)
       expect(person.roles.with_deleted.with_membership_years.first.membership_years)
-        .to eq(0.9973)
+        .to be_within(0.01).of(0.99)
     end
 
     it "calculates value up to passed reporting date" do
@@ -458,7 +458,7 @@ describe Role do
     it "calculates value and does not include last day for reporting date" do
       create_role(created_at: 1.year.ago, delete_on: 5.years.from_now)
       expect(person.roles.with_membership_years("roles.*", 2.years.from_now - 1.days).first.membership_years)
-        .to eq(2.9973)
+        .to be_within(0.01).of(2.99)
     end
 
     (SacCas::MITGLIED_ROLES - [Group::SektionsMitglieder::Mitglied]).each do |role_type|

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -446,7 +446,19 @@ describe Role do
     it "calculates value and does not include last day for date today" do
       create_role(created_at: 1.year.ago + 1.days, delete_on: 2.years.from_now)
       expect(person.roles.with_deleted.with_membership_years.first.membership_years)
-        .to eq(0.9993)
+        .to eq(0.9973)
+    end
+
+    it "calculates value up to passed reporting date" do
+      create_role(created_at: 1.year.ago, delete_on: 5.years.from_now)
+      expect(person.roles.with_membership_years("roles.*", 2.years.from_now).first.membership_years)
+        .to eq(3.0)
+    end
+
+    it "calculates value and does not include last day for reporting date" do
+      create_role(created_at: 1.year.ago, delete_on: 5.years.from_now)
+      expect(person.roles.with_membership_years("roles.*", 2.years.from_now - 1.days).first.membership_years)
+        .to eq(2.9973)
     end
 
     (SacCas::MITGLIED_ROLES - [Group::SektionsMitglieder::Mitglied]).each do |role_type|


### PR DESCRIPTION

For PostgreSQL we have to adjust the query a little bit, here is the PostgreSQL conform version of the new query:
```
CASE
    -- membership_years is only calculated for Mitglied roles
    WHEN roles.type != 'Group::SektionsMitglieder::Mitglied' THEN 0
    ELSE (
        EXTRACT(
            YEAR FROM age(
                LEAST(
                    DATE('#{date.strftime("%Y-%m-%d")}'),
                    COALESCE(
                        DATE(CONVERT_TZ(roles.deleted_at, 'UTC', 'CET')) + INTERVAL '1 day',
                        '9999-12-31'
                    ),
                    COALESCE(
                        DATE(CONVERT_TZ(roles.archived_at, 'UTC', 'CET')) + INTERVAL '1 day',
                        '9999-12-31'
                    ),
                    COALESCE(
                        roles.delete_on + INTERVAL '1 day',
                        '9999-12-31'
                    )
                )::DATE,
                CONVERT_TZ(roles.created_at, 'UTC', 'CET')::DATE
            )
        ) 
        + CASE
            -- check if dates are the same, to not add fractional year
            WHEN (
                EXTRACT(MONTH FROM LEAST(
                    DATE('#{date.strftime("%Y-%m-%d")}'),
                    COALESCE(
                        DATE(CONVERT_TZ(roles.deleted_at, 'UTC', 'CET')) + INTERVAL '1 day',
                        '9999-12-31'
                    ),
                    COALESCE(
                        DATE(CONVERT_TZ(roles.archived_at, 'UTC', 'CET')) + INTERVAL '1 day',
                        '9999-12-31'
                    ),
                    COALESCE(
                        roles.delete_on + INTERVAL '1 day',
                        '9999-12-31'
                    )
                )) = EXTRACT(MONTH FROM CONVERT_TZ(roles.created_at, 'UTC', 'CET')::DATE) AND
                EXTRACT(DAY FROM LEAST(
                    DATE('#{date.strftime("%Y-%m-%d")}'),
                    COALESCE(
                        DATE(CONVERT_TZ(roles.deleted_at, 'UTC', 'CET')) + INTERVAL '1 day',
                        '9999-12-31'
                    ),
                    COALESCE(
                        DATE(CONVERT_TZ(roles.archived_at, 'UTC', 'CET')) + INTERVAL '1 day',
                        '9999-12-31'
                    ),
                    COALESCE(
                        roles.delete_on + INTERVAL '1 day',
                        '9999-12-31'
                    )
                )) = EXTRACT(DAY FROM CONVERT_TZ(roles.created_at, 'UTC', 'CET')::DATE)
            ) THEN 0
            ELSE (
                -- calculate the fractional year
                DATE_PART(
                    'day',
                    LEAST(
                        DATE('#{date.strftime("%Y-%m-%d")}'),
                        COALESCE(
                            DATE(CONVERT_TZ(roles.deleted_at, 'UTC', 'CET')),
                            '9999-12-31'
                        ),
                        COALESCE(
                            DATE(CONVERT_TZ(roles.archived_at, 'UTC', 'CET')),
                            '9999-12-31'
                        ),
                        COALESCE(
                            roles.delete_on,
                            '9999-12-31'
                        )
                    ) - DATE(
                        CONVERT_TZ(roles.created_at, 'UTC', 'CET') + INTERVAL '1 day' * EXTRACT(YEAR FROM age(
                            LEAST(
                                DATE('#{date.strftime("%Y-%m-%d")}'),
                                COALESCE(
                                    DATE(CONVERT_TZ(roles.deleted_at, 'UTC', 'CET')),
                                    '9999-12-31'
                                ),
                                COALESCE(
                                    DATE(CONVERT_TZ(roles.archived_at, 'UTC', 'CET')),
                                    '9999-12-31'
                                ),
                                COALESCE(
                                    roles.delete_on,
                                    '9999-12-31'
                                )
                            )::DATE,
                            CONVERT_TZ(roles.created_at, 'UTC', 'CET')::DATE
                        ))::INTEGER
                    )
                ) / CASE 
                    WHEN EXTRACT(DAY FROM DATE_TRUNC('MONTH', DATE('#{date.strftime("%Y-%m-%d")}') + INTERVAL '1 MONTH') - INTERVAL '1 day') = 29 
                    THEN 366 
                    ELSE 365 
                END
            )
        END
    )
END AS membership_years

```