### PR TITLE
INVOICE: Yearly invoices job

### DIFF
--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -112,6 +112,7 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
   def process_invoices
     raise_exception = nil
     start_progress
+    clear_spurious_draft_invoices!
     active_members.in_batches(of: BATCH_SIZE) do |people|
       people_ids = people.pluck(:id)
       slices = people_ids.each_slice(SLICE_SIZE).to_a
@@ -131,6 +132,10 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
       end
       update_progress(people_ids.size)
     end
+  end
+
+  def clear_spurious_draft_invoices!
+    ExternalInvoice::SacMembership.where(state: :draft).destroy_all
   end
 
   def load_people(ids)

--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -28,7 +28,6 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
   end
 
   def perform
-    assert_no_other_job_running!
     # log start according to ticket
     extend_roles_for_invoicing
     # process_invoices

--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -136,11 +136,12 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
   end
 
   def create_log_entry(part)
+    part.context_object.entity.update!(state: :error)
     HitobitoLogEntry.create!(
       subject: part.context_object.entity,
       category: "rechnungen",
       level: :error,
-      message: "TODO",
+      message: "Mitgliedschaftsrechnung konnte nicht in Abacus erstellt werden",
       payload: part.error_payload
     )
   end

--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -28,6 +28,15 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
     super
   end
 
+  def error(job, exception)
+    HitobitoLogEntry.create!(
+      category: "stapelverarbeitung",
+      level: :error,
+      message: "Mitgliedschaftsrechnungen konnten nicht an Abacus übermittelt werden. Es erfolgt ein weiterer Versuch.",
+      payload: exception.message
+    )
+  end
+
   def perform
     log_progress(0)
     extend_roles_for_invoicing
@@ -86,7 +95,7 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
         end
       # rubocop:disable Lint/RescueException we want to catch and re-raise all exceptions
       rescue Exception => e
-        Rails.logger.error "Error while creating invoices: #{e.response.body}"
+        Rails.logger.error "Error while creating invoices: #{e.message}"
         raise_exception = e
         raise Parallel::Break
       end

--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -135,7 +135,7 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
   end
 
   def context
-    @context ||= Invoices::SacMemberships::Context.new(@invoice_date)
+    @context ||= Invoices::SacMemberships::Context.new(Date.new(@invoice_year))
   end
 
   def sales_order_interface

--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -159,10 +159,8 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
   def membership_invoices(people)
     people.filter_map do |person|
       member = Invoices::SacMemberships::Member.new(person, context)
-      if member.stammsektion_role
-        invoice = Invoices::Abacus::MembershipInvoice.new(member, member.active_memberships)
-        invoice if invoice.invoice?
-      end
+      invoice = Invoices::Abacus::MembershipInvoice.new(member, member.active_memberships)
+      invoice if invoice.invoice?
     end
   end
 

--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -140,14 +140,15 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
   def create_invoices(people)
     membership_invoices = membership_invoices(people)
     sales_orders = create_sales_orders(membership_invoices)
-
-    parts = begin
-      sales_order_interface.create_batch(sales_orders)
-    rescue RestClient::Exception => e
-      clear_external_invoices(sales_orders)
-      raise e
-    end
+    parts = submit_sales_orders(sales_orders)
     log_error_parts(parts)
+  end
+
+  def submit_sales_orders(sales_orders)
+    sales_order_interface.create_batch(sales_orders)
+  rescue RestClient::Exception => e
+    clear_external_invoices(sales_orders)
+    raise e
   end
 
   def clear_external_invoices(sales_orders)

--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -44,6 +44,7 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
       .where(roles: {type: Group::SektionsMitglieder::Mitglied.sti_name})
       .left_outer_joins(:external_invoices)
       .where("external_invoices.id IS NULL OR external_invoices.type != ? OR external_invoices.year != ?", ExternalInvoice::SacMembership.sti_name, @invoice_year)
+      .distinct
   end
 
   private

--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -29,12 +29,13 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
   end
 
   def error(job, exception)
-    HitobitoLogEntry.create!(
-      category: "stapelverarbeitung",
-      level: :error,
-      message: "Mitgliedschaftsrechnungen konnten nicht an Abacus übermittelt werden. Es erfolgt ein weiterer Versuch.",
-      payload: exception.message
-    )
+    super
+    create_error_log_entry("Mitgliedschaftsrechnungen konnten nicht an Abacus übermittelt werden. " \
+              "Es erfolgt ein weiterer Versuch.", exception.message)
+  end
+
+  def failure(job)
+    create_error_log_entry("MV-Jahresinkassolauf abgebrochen", nil)
   end
 
   def perform
@@ -63,6 +64,15 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
       category: "stapelverarbeitung",
       level: :info,
       message: "MV-Jahresinkassolauf: Fortschritt #{percent}%"
+    )
+  end
+
+  def create_error_log_entry(message, payload)
+    HitobitoLogEntry.create!(
+      category: "stapelverarbeitung",
+      level: :error,
+      message: message,
+      payload: payload
     )
   end
 

--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -84,7 +84,7 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
     end
   end
 
-  def create_external_invoice(membership_invoice) # rubocop:disable Metrics/MethodLength
+  def create_external_invoice(membership_invoice)
     ExternalInvoice::SacMembership.create!(
       person: membership_invoice.member.person,
       year: @invoice_year,

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -32,7 +32,7 @@ module HitobitoSacCas
         Qualifications::ExpirationMailerJob,
         Roles::TerminateTourenleiterJob
       ]
-      HitobitoLogEntry.categories += %w[neuanmeldungen rechnungen]
+      HitobitoLogEntry.categories += %w[neuanmeldungen rechnungen stapelverarbeitung]
 
       # extend application classes here
       Event.prepend SacCas::Event

--- a/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
+++ b/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
@@ -7,9 +7,12 @@
 
 require "spec_helper"
 
+class ExternalInvoice::DummyInvoice < ExternalInvoice
+end
+
 describe Invoices::Abacus::CreateYearlyInvoicesJob do
   let(:params) { {invoice_year:, invoice_date:, send_date:, role_finish_date:} }
-  let(:invoice_year) { nil }
+  let(:invoice_year) { 2024 }
   let(:invoice_date) { nil }
   let(:send_date) { nil }
   let(:role_finish_date) { nil }
@@ -19,6 +22,47 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
     it "will create a job and raise if there is already one running" do
       expect { subject.enqueue! }.to change(Delayed::Job, :count).by(1)
       expect { subject.enqueue! }.to raise_error("There is already a job running")
+    end
+  end
+
+  def create_person(role_created_at: Date.new(invoice_year, 1, 1), params: {})
+    group = groups(:bluemlisalp_mitglieder)
+    person = Fabricate.create(:person_with_address, **params)
+    Fabricate.create(Group::SektionsMitglieder::Mitglied.sti_name, created_at: role_created_at, group:, person:)
+    person
+  end
+
+  describe "#active_members" do
+    context "without any people that have an abacus_subject_key" do
+      it "returns an empty array" do
+        expect(subject.active_members).to eq []
+      end
+    end
+
+    context "with a wild mix of people" do
+      before do
+        # People that shouldn't show up
+        people(:familienmitglied2).update!(abacus_subject_key: "125", data_quality: :error)
+        create_person(role_created_at: Date.new(invoice_year, 8, 16), params: {abacus_subject_key: "126"})
+        person = create_person(params: {abacus_subject_key: "127"})
+        person.external_invoices.create!(type: ExternalInvoice::SacMembership, year: invoice_year)
+
+        # People that should show up
+        people(:mitglied).update!(abacus_subject_key: "123")
+        people(:familienmitglied).update!(abacus_subject_key: "124")
+        valid_person = create_person(params: {abacus_subject_key: "128"})
+        valid_person.external_invoices.create!(type: ExternalInvoice::DummyInvoice, year: invoice_year)
+        @expected_people = [
+          people(:mitglied),
+          people(:familienmitglied),
+          valid_person,
+          create_person(params: {abacus_subject_key: "129"})
+        ]
+      end
+
+      it "returns the correct people" do
+        expect(subject.active_members).to match_array(@expected_people)
+      end
     end
   end
 end

--- a/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
+++ b/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
@@ -13,10 +13,37 @@ end
 describe Invoices::Abacus::CreateYearlyInvoicesJob do
   let(:params) { {invoice_year:, invoice_date:, send_date:, role_finish_date:} }
   let(:invoice_year) { 2024 }
-  let(:invoice_date) { Date.new(2024, 12, 31) }
-  let(:send_date) { nil }
+  let(:invoice_date) { Date.new(2025, 1, 1) }
+  let(:send_date) { Date.new(2025, 1, 2) }
   let(:role_finish_date) { nil }
   let(:subject) { described_class.new(**params) }
+
+  let(:mix_of_people) do
+    # People that shouldn't show up
+    people(:familienmitglied2).update!(abacus_subject_key: "125", data_quality: :error)
+    person_1 = create_person(role_created_at: Date.new(invoice_year, 8, 16), params: {abacus_subject_key: "126"})
+    person_2 = create_person(params: {abacus_subject_key: "127"})
+    person_2.external_invoices.create!(type: ExternalInvoice::SacMembership, year: invoice_year)
+
+    # People that should show up
+    people(:mitglied).update!(abacus_subject_key: "123")
+    people(:familienmitglied).update!(abacus_subject_key: "124")
+    # valid_person = create_person(params: {abacus_subject_key: "128"})
+    # valid_person.external_invoices.create!(type: ExternalInvoice::DummyInvoice, year: invoice_year)
+    [
+      [
+        people(:mitglied),
+        people(:familienmitglied)
+        # valid_person,
+        # create_person(params: {abacus_subject_key: "129"})
+      ],
+      [
+        people(:familienmitglied2),
+        person_1,
+        person_2
+      ]
+    ]
+  end
 
   describe "#enqueue!" do
     it "will create a job and raise if there is already one running" do
@@ -41,23 +68,7 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
 
     context "with a wild mix of people" do
       before do
-        # People that shouldn't show up
-        people(:familienmitglied2).update!(abacus_subject_key: "125", data_quality: :error)
-        create_person(role_created_at: Date.new(invoice_year, 8, 16), params: {abacus_subject_key: "126"})
-        person = create_person(params: {abacus_subject_key: "127"})
-        person.external_invoices.create!(type: ExternalInvoice::SacMembership, year: invoice_year)
-
-        # People that should show up
-        people(:mitglied).update!(abacus_subject_key: "123")
-        people(:familienmitglied).update!(abacus_subject_key: "124")
-        valid_person = create_person(params: {abacus_subject_key: "128"})
-        valid_person.external_invoices.create!(type: ExternalInvoice::DummyInvoice, year: invoice_year)
-        @expected_people = [
-          people(:mitglied),
-          people(:familienmitglied),
-          valid_person,
-          create_person(params: {abacus_subject_key: "129"})
-        ]
+        @expected_people = mix_of_people[0]
       end
 
       it "returns the correct people" do
@@ -69,19 +80,93 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
   describe "#perform" do
     let(:host) { "https://abacus.example.com" }
     let(:mandant) { 1234 }
+    let(:today) { Time.zone.today.strftime("%Y-%m-%d") }
+    let(:dummy_invoice) do
+      ExternalInvoice::SacMembership.create!(
+        person: people.last,
+        issued_at: today,
+        sent_at: today
+      )
+    end
+    let(:next_invoice_id) { dummy_invoice.id + 1 }
+
+    let(:abacus_client) { Invoices::Abacus::Client.new }
+    let(:sales_order_interface) { Invoices::Abacus::SalesOrderInterface.new(abacus_client) }
+    let(:expected_people) { mix_of_people[0] }
 
     before do
+      expected_people
       Invoices::Abacus::Config.instance_variable_set(:@config, {host: host, mandant: mandant}.stringify_keys)
-    end
-
-    let!(:people) do
-      10.times do |i|
-        create_person(params: {abacus_subject_key: "12#{i}"})
-      end
+      allow(Invoices::Abacus::SalesOrderInterface).to receive(:new).and_return(sales_order_interface)
+      allow(abacus_client).to receive(:token).and_return("42")
+      allow(abacus_client).to receive(:generate_batch_boundary).and_return("batch-boundary-3f8b206b-4aec-4616-bd28-c1ccbe572649")
+      stub_request(:post, "#{host}/api/entity/v1/mandants/1234/$batch")
+        .with(
+          body: batch_body_sales_orders,
+          headers: {
+            "Authorization" => "Bearer 42",
+            "Content-Type" => "multipart/mixed;boundary=batch-boundary-3f8b206b-4aec-4616-bd28-c1ccbe572649"
+          }
+        )
+        .to_return(
+          status: 202,
+          body: batch_response_sales_orders,
+          headers: {"Content-Type" => "multipart/mixed;boundary=batch-boundary-3f8b206b-4aec-4616-bd28-asdasdfasdf"}
+        )
     end
 
     it "works" do
-      expect { subject.perform }.not_to raise_error
+      p next_invoice_id
+      expect { subject.perform }
+        .to change { ExternalInvoice.count }.by(2)
     end
+  end
+
+  def batch_body_sales_orders
+    <<~HTTP
+      --batch-boundary-3f8b206b-4aec-4616-bd28-c1ccbe572649\r
+      Content-Type: application/http\r
+      Content-Transfer-Encoding: binary\r
+      \r
+      POST SalesOrders HTTP/1.1\r
+      Content-Type: application/json\r
+      Accept: application/json\r
+      \r
+      {"CustomerId":123,"OrderDate":"#{invoice_date}","DeliveryDate":"#{send_date}","TotalAmount":183.0,"DocumentCodeInvoice":"R","Language":"de","UserFields":{"UserField1":"#{next_invoice_id}","UserField2":"hitobito","UserField3":true,"UserField4":1.0,"UserField11":"600001;Hillary;Edmund;#{expected_people[0].membership_verify_token}"},"Positions":[{"PositionNumber":1,"Type":"Product","Pricing":{"PriceAfterFinding":40.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Beitrag Zentralverband","ProductNumber":"42"},"Accounts":{},"UserFields":{"UserField1":"Beitrag Zentralverband","UserField4":"Einzelmitglied"}},{"PositionNumber":2,"Type":"Product","Pricing":{"PriceAfterFinding":20.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Hütten Solidaritätsbeitrag","ProductNumber":"44"},"Accounts":{},"UserFields":{"UserField1":"Beitrag Zentralverband","UserField4":"Einzelmitglied"}},{"PositionNumber":3,"Type":"Product","Pricing":{"PriceAfterFinding":25.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Alpengebühren","ProductNumber":"45"},"Accounts":{},"UserFields":{"UserField1":"Beitrag Zentralverband","UserField4":"Einzelmitglied"}},{"PositionNumber":4,"Type":"Product","Pricing":{"PriceAfterFinding":42.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Beitrag SAC Blüemlisalp","ProductNumber":"98"},"Accounts":{},"UserFields":{"UserField1":"Beitrag SAC Blüemlisalp","UserField2":578575972,"UserField4":"Einzelmitglied"}},{"PositionNumber":5,"Type":"Product","Pricing":{"PriceAfterFinding":56.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Beitrag SAC Matterhorn","ProductNumber":"98"},"Accounts":{},"UserFields":{"UserField1":"Beitrag SAC Matterhorn","UserField2":#{groups(:matterhorn).id},"UserField4":"Einzelmitglied"}}]}\r
+      --batch-boundary-3f8b206b-4aec-4616-bd28-c1ccbe572649\r
+      Content-Type: application/http\r
+      Content-Transfer-Encoding: binary\r
+      \r
+      POST SalesOrders HTTP/1.1\r
+      Content-Type: application/json\r
+      Accept: application/json\r
+      \r
+      {"CustomerId":124,"OrderDate":"#{invoice_date}","DeliveryDate":"2025-01-02","TotalAmount":267.0,"DocumentCodeInvoice":"R","Language":"de","UserFields":{"UserField1":"4","UserField2":"hitobito","UserField3":true,"UserField4":1.0,"UserField11":"600002;Norgay;Tenzing;#{expected_people[1].membership_verify_token}","UserField12":"600003;Norgay;Frieda;#{people(:familienmitglied2).membership_verify_token}","UserField13":"600004;Norgay;Nima;#{people(:familienmitglied_kind).membership_verify_token}"},"Positions":[{"PositionNumber":1,"Type":"Product","Pricing":{"PriceAfterFinding":50.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Beitrag Zentralverband","ProductNumber":"42"},"Accounts":{},"UserFields":{"UserField1":"Beitrag Zentralverband","UserField4":"Familienmitglied"}},{"PositionNumber":2,"Type":"Product","Pricing":{"PriceAfterFinding":20.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Hütten Solidaritätsbeitrag","ProductNumber":"44"},"Accounts":{},"UserFields":{"UserField1":"Beitrag Zentralverband","UserField4":"Familienmitglied"}},{"PositionNumber":3,"Type":"Product","Pricing":{"PriceAfterFinding":25.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Alpengebühren","ProductNumber":"45"},"Accounts":{},"UserFields":{"UserField1":"Beitrag Zentralverband","UserField4":"Familienmitglied"}},{"PositionNumber":4,"Type":"Product","Pricing":{"PriceAfterFinding":84.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Beitrag SAC Blüemlisalp","ProductNumber":"98"},"Accounts":{},"UserFields":{"UserField1":"Beitrag SAC Blüemlisalp","UserField2":#{groups(:bluemlisalp).id},"UserField4":"Familienmitglied"}},{"PositionNumber":5,"Type":"Product","Pricing":{"PriceAfterFinding":88.0},"Quantity":{"Ordered":1,"Charged":1,"Delivered":1},"Product":{"Description":"Beitrag SAC Matterhorn","ProductNumber":"98"},"Accounts":{},"UserFields":{"UserField1":"Beitrag SAC Matterhorn","UserField2":#{groups(:matterhorn).id},"UserField4":"Familienmitglied"}}]}\r
+      --batch-boundary-3f8b206b-4aec-4616-bd28-c1ccbe572649--\r
+    HTTP
+  end
+
+  def batch_response_sales_orders
+    <<~HTTP
+      --batch-boundary-3f8b206b-4aec-4616-bd28-asdasdfasdf\r
+      Content-Type: application/http\r
+      Content-Transfer-Encoding: binary\r
+      \r
+      HTTP/1.1 201 Created\r
+      Content-Type: application/json\r
+      Accept: application/json\r
+      \r
+      {"SalesOrderId":42,"SalesOrderBacklogId":0}\r
+      --batch-boundary-3f8b206b-4aec-4616-bd28-asdasdfasdf\r
+      Content-Type: application/http\r
+      Content-Transfer-Encoding: binary\r
+      \r
+      HTTP/1.1 201 Created\r
+      Content-Type: application/json\r
+      Accept: application/json\r
+      \r
+      {"SalesOrderId":45,"SalesOrderBacklogId":0}\r
+      --batch-boundary-3f8b206b-4aec-4616-bd28-asdasdfasdf--\r
+    HTTP
   end
 end

--- a/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
+++ b/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
@@ -147,7 +147,7 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
         expect { Delayed::Worker.new.run(job_instance) }
           .to change(ExternalInvoice, :count).by(4)
           .and change { HitobitoLogEntry.where(level: :error).count }.by(1)
-          .and change { HitobitoLogEntry.where(level: :info).count }.by(3)
+          .and change { HitobitoLogEntry.where(level: :info).count }.by(4)
         expect(ExternalInvoice.last.state).to eq("error")
         expect(HitobitoLogEntry.where(level: :info).last.message).to eq("MV-Jahresinkassolauf: Fortschritt 100%")
       end
@@ -159,7 +159,7 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
           expect { Delayed::Worker.new.run(job_instance) }
             .to change(ExternalInvoice, :count).by(4)
             .and change { HitobitoLogEntry.where(level: :error).count }.by(1)
-            .and change { HitobitoLogEntry.where(level: :info).count }.by(3)
+            .and change { HitobitoLogEntry.where(level: :info).count }.by(4)
           expect(ExternalInvoice.where(state: :draft).count).to be_zero
           expect(ExternalInvoice.last.state).to eq("error")
           expect(HitobitoLogEntry.where(level: :info).last.message).to eq("MV-Jahresinkassolauf: Fortschritt 100%")
@@ -211,7 +211,7 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
         # retry job to trigger failure
         expect { Delayed::Worker.new.run(job_instance) }
           .to not_change(ExternalInvoice, :count)
-          .and change { HitobitoLogEntry.where(level: :info).count }.by(2)
+          .and change { HitobitoLogEntry.where(level: :info).count }.by(1)
           .and change { HitobitoLogEntry.where(level: :error).count }.by(2)
         expect(HitobitoLogEntry.where(level: :error).last.message).to eq("MV-Jahresinkassolauf abgebrochen")
         expect(ExternalInvoice.where(state: :draft).count).to be_zero

--- a/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
+++ b/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
@@ -144,7 +144,7 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
       end
 
       it "Creates the invoices and error logs" do
-        expect { Delayed::Worker.new.run(job_instance) }
+        expect { subject.perform }
           .to change(ExternalInvoice, :count).by(4)
           .and change { HitobitoLogEntry.where(level: :error).count }.by(1)
           .and change { HitobitoLogEntry.where(level: :info).count }.by(4)
@@ -156,7 +156,7 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
         let(:role_finish_date) { Date.new(invoice_year, 12, 31) }
 
         it "Creates the invoices and error logs" do
-          expect { Delayed::Worker.new.run(job_instance) }
+          expect { subject.perform }
             .to change(ExternalInvoice, :count).by(4)
             .and change { HitobitoLogEntry.where(level: :error).count }.by(1)
             .and change { HitobitoLogEntry.where(level: :info).count }.by(4)

--- a/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
+++ b/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require "spec_helper"
+
+describe Invoices::Abacus::CreateYearlyInvoicesJob do
+  let(:params) { {invoice_year:, invoice_date:, send_date:, role_finish_date:} }
+  let(:invoice_year) { nil }
+  let(:invoice_date) { nil }
+  let(:send_date) { nil }
+  let(:role_finish_date) { nil }
+  let(:subject) { described_class.new(**params) }
+
+  describe "#enqueue!" do
+    it "will create a job and raise if there is already one running" do
+      expect { subject.enqueue! }.to change(Delayed::Job, :count).by(1)
+      expect { subject.enqueue! }.to raise_error("There is already a job running")
+    end
+  end
+end

--- a/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
+++ b/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
@@ -13,7 +13,7 @@ end
 describe Invoices::Abacus::CreateYearlyInvoicesJob do
   let(:params) { {invoice_year:, invoice_date:, send_date:, role_finish_date:} }
   let(:invoice_year) { 2024 }
-  let(:invoice_date) { nil }
+  let(:invoice_date) { Date.new(2024, 12, 31) }
   let(:send_date) { nil }
   let(:role_finish_date) { nil }
   let(:subject) { described_class.new(**params) }
@@ -63,6 +63,25 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
       it "returns the correct people" do
         expect(subject.active_members).to match_array(@expected_people)
       end
+    end
+  end
+
+  describe "#perform" do
+    let(:host) { "https://abacus.example.com" }
+    let(:mandant) { 1234 }
+
+    before do
+      Invoices::Abacus::Config.instance_variable_set(:@config, {host: host, mandant: mandant}.stringify_keys)
+    end
+
+    let!(:people) do
+      10.times do |i|
+        create_person(params: {abacus_subject_key: "12#{i}"})
+      end
+    end
+
+    it "works" do
+      expect { subject.perform }.not_to raise_error
     end
   end
 end

--- a/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
+++ b/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
@@ -134,8 +134,10 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
     it "Creates the invoices and error logs" do
       expect { subject.perform }
         .to change(ExternalInvoice, :count).by(2)
-        .and change(HitobitoLogEntry, :count).by(1)
+        .and change { HitobitoLogEntry.where(level: :error).count }.by(1)
+        .and change { HitobitoLogEntry.where(level: :info).count }.by(3)
       expect(ExternalInvoice.last.state).to eq("error")
+      expect(HitobitoLogEntry.where(level: :info).last.message).to eq("MV-Jahresinkassolauf: Fortschritt 100%")
     end
   end
 

--- a/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
+++ b/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
@@ -135,6 +135,7 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
       expect { subject.perform }
         .to change(ExternalInvoice, :count).by(2)
         .and change(HitobitoLogEntry, :count).by(1)
+      expect(ExternalInvoice.last.state).to eq("error")
     end
   end
 


### PR DESCRIPTION
Fixes #803 

 - [x] Based on #871 
 - [X] Avoid running multiple jobs at the same time
 - [x] Call `extend_roles_for_invoicing` based on if `role_finish_date` is given
 - [X] Implement `active_members`
 - [x] Implement actual invoice sending
 - [x] Implement thorough error handling
 - [x] Implement progress log
 - [x]  Via das error Callback von Delayed Job wird ein HitobitoLogEntry erstellt (category: "Stapelverarbeitung", kein Subject, Level Error, Message "MV-Jahresinkassolauf: Mitgliedschaftsrechnungen konnten nicht an Abacus übermittelt werden. Es erfolgt ein weiterer Versuch.", Payload exception.message). Falls alle Versuche fehlschlagen, wird über das failure Callback ein letzter HitobitoLogEntry mit der Message "MV-Jahresinkassolauf abgebrochen" erstellt.
