### PR TITLE
INVOICE: Fix active_members query

### DIFF
--- a/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
+++ b/app/jobs/invoices/abacus/create_yearly_invoices_job.rb
@@ -51,8 +51,7 @@ class Invoices::Abacus::CreateYearlyInvoicesJob < BaseJob
       .joins(:roles)
       .merge(Role.active(reference_date))
       .where(roles: {type: Group::SektionsMitglieder::Mitglied.sti_name})
-      .left_outer_joins(:external_invoices)
-      .where("external_invoices.id IS NULL OR external_invoices.type != ? OR external_invoices.year != ?", ExternalInvoice::SacMembership.sti_name, @invoice_year)
+      .where.not(id: ExternalInvoice::SacMembership.where(year: @invoice_year).select(:person_id))
       .distinct
   end
 

--- a/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
+++ b/spec/jobs/invoices/abacus/create_yearly_invoices_job_spec.rb
@@ -39,10 +39,17 @@ describe Invoices::Abacus::CreateYearlyInvoicesJob do
     person_1 = create_person(role_created_at: Date.new(invoice_year, 8, 16), params: {abacus_subject_key: "126"})
     person_2 = create_person(params: {abacus_subject_key: "127"})
     person_2.external_invoices.create!(type: ExternalInvoice::SacMembership, year: invoice_year, state: :open)
+
+    # reproduction case where the query returned people which had a different
+    # invoice additionally to the SacMembership invoice
+    person_3 = create_person(params: {abacus_subject_key: "301"})
+    person_3.external_invoices.create!(type: ExternalInvoice::SacMembership, year: invoice_year, state: :open)
+    person_3.external_invoices.create!(type: ExternalInvoice::DummyInvoice, year: invoice_year, state: :open)
     [
       people(:familienmitglied2),
       person_1,
-      person_2
+      person_2,
+      person_3
     ]
   end
 


### PR DESCRIPTION
Ref: #803 
Previously members with an SacMembership invoice from 2024 and another invoice would also get selected.