### PR TITLE
fix flaky abacus spec: order of family members

### DIFF
--- a/app/domain/invoices/sac_memberships/member.rb
+++ b/app/domain/invoices/sac_memberships/member.rb
@@ -81,7 +81,7 @@ module Invoices
       end
 
       def family_members
-        person.household_people.select { |p| sac_mitgliedschaft?(p) }
+        person.household_people.select { |p| sac_mitgliedschaft?(p) }.sort_by(&:id)
       end
 
       private


### PR DESCRIPTION
In run  https://github.com/hitobito/hitobito_sac_cas/actions/runs/11048637113/job/30692422707?pr=1034
we see that the abacus spec fails because the github CI somehow manages to get the family members back in a different order (i assume different locales / collections in the database). This should fix the reoccurence of this flaky spec.
