### PR TITLE
Prevent `ExternalInvoice::Course` from enqueuing the same invoice multiple times

### DIFF
--- a/app/models/external_invoice/course.rb
+++ b/app/models/external_invoice/course.rb
@@ -35,7 +35,7 @@ class ExternalInvoice::Course < ExternalInvoice
 
   class << self
     def invoice_participation(participation)
-      return if participation.price.nil?
+      return if participation.price.nil? || ExternalInvoice::Course.exists?(link: participation)
 
       external_invoice = ExternalInvoice::Course.create(
         person: participation.person,


### PR DESCRIPTION
Fixes #1013