### PR TITLE
Render markdown tables in CustomContent

### DIFF
--- a/app/domain/render_markdown_tables.rb
+++ b/app/domain/render_markdown_tables.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module RenderMarkdownTables
+  require "redcarpet"
+
+  MARKDOWN_TABLE_PATTERN = %r{(\|([^|<]*\|)+(?:<br>))+}
+
+  def self.replace_markdown_tables(body)
+    body.gsub(MARKDOWN_TABLE_PATTERN) do |markdown|
+      Redcarpet::Markdown.new(Redcarpet::Render::HTML, tables: true).render(markdown.gsub("<br>", "\n"))
+    end.delete("\n").html_safe
+  end
+end

--- a/app/models/sac_cas/custom_content.rb
+++ b/app/models/sac_cas/custom_content.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+# == Schema Information
+#
+# Table name: custom_contents
+#
+#  id                    :integer          not null, primary key
+#  key                   :string           not null
+#  label                 :string           not null
+#  placeholders_optional :string
+#  placeholders_required :string
+#  subject               :string
+#
+
+module SacCas::CustomContent
+  extend ActiveSupport::Concern
+
+  def body_with_values(placeholders = {})
+    body.to_s.html_safe
+      .then { RenderMarkdownTables.replace_markdown_tables(_1) }
+      .then { replace_placeholders(_1, placeholders) }
+  end
+end

--- a/app/views/layouts/_mailer_head_sac.html.haml
+++ b/app/views/layouts/_mailer_head_sac.html.haml
@@ -21,7 +21,7 @@
   tr {
     border-top: 1px solid var(--lightgray);
   }
-  tr:first-child {
+  thead tr {
     border-top: none;
   }
 

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -44,6 +44,7 @@ module HitobitoSacCas
       HitobitoLogEntry.categories += %w[neuanmeldungen rechnungen stapelverarbeitung]
 
       # extend application classes here
+      CustomContent.prepend SacCas::CustomContent
       Event.prepend SacCas::Event
       Event::Kind.prepend SacCas::Event::Kind
       Event::Course.prepend SacCas::Event::Course

--- a/spec/models/custom_content_spec.rb
+++ b/spec/models/custom_content_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe SacCas::CustomContent do
+  subject { CustomContent.get(Event::ParticipationMailer::REJECT_APPLIED_PARTICIPATION) }
+
+  let(:output) do
+    subject.body_with_values("event-name" => "Example|Event", "event-link" => "example.com/event")
+  end
+
+  def trim(string)
+    string.gsub(/^ +|\n/, "")
+  end
+
+  context "#body_with_values" do
+    it "replaces all placeholders and markdown tables" do
+      subject.body =
+        "This is a markdown table:<br>" \
+        "| Name       | Link         |<br>" \
+        "| ---------- | ------------ |<br>" \
+        "| Event-Name | {event-name} |<br>" \
+        "| Event-Link | {event-link} |<br>" \
+        "Here is another one:<br>" \
+        "| Name       | Link         |<br>" \
+        "| ---------- | ------------ |<br>" \
+        "| Event-Name | Eventus      |<br>"
+
+      expect(output).to include(trim(
+        "This is a markdown table:<br>\n" \
+        "<table>\n" \
+        "  <thead>\n" \
+        "    <tr>\n" \
+        "      <th>Name</th>\n" \
+        "      <th>Link</th>\n" \
+        "    </tr>\n" \
+        "  </thead>\n" \
+        "  <tbody>\n" \
+        "    <tr>\n" \
+        "      <td>Event-Name</td>\n" \
+        "      <td>Example|Event</td>\n" \
+        "    </tr>\n" \
+        "    <tr>\n" \
+        "      <td>Event-Link</td>\n" \
+        "      <td>example.com/event</td>\n" \
+        "    </tr>\n" \
+        "  </tbody>\n" \
+        "</table>\n" \
+        "Here is another one:<br>\n" \
+        "<table>\n" \
+        "  <thead>\n" \
+        "    <tr>\n" \
+        "      <th>Name</th>\n" \
+        "      <th>Link</th>\n" \
+        "    </tr>\n" \
+        "  </thead>\n" \
+        "  <tbody>\n" \
+        "    <tr>\n" \
+        "      <td>Event-Name</td>\n" \
+        "      <td>Eventus</td>\n" \
+        "    </tr>\n" \
+        "  </tbody>\n" \
+        "</table>"
+      ))
+    end
+
+    it "replaces markdown tables with empty fields" do
+      subject.body =
+        "| Name | Link |<br>" \
+        "| - | - |<br>" \
+        "| | {event-name} |<br>"
+
+      expect(output).to include(trim(
+        "<table>\n" \
+        "  <thead>\n" \
+        "    <tr>\n" \
+        "      <th>Name</th>\n" \
+        "      <th>Link</th>\n" \
+        "    </tr>\n" \
+        "  </thead>\n" \
+        "  <tbody>\n" \
+        "    <tr>\n" \
+        "      <td></td>\n" \
+        "      <td>Example|Event</td>\n" \
+        "    </tr>\n" \
+        "  </tbody>\n" \
+        "</table>"
+      ))
+    end
+
+    it "replaces markdown tables with single column" do
+      subject.body =
+        "| Link         |<br>" \
+        "| ------------ |<br>" \
+        "| {event-name} |<br>"
+
+      expect(output).to include(trim(
+        "<table>\n" \
+        "  <thead>\n" \
+        "    <tr>\n" \
+        "      <th>Link</th>\n" \
+        "    </tr>\n" \
+        "  </thead>\n" \
+        "  <tbody>\n" \
+        "    <tr>\n" \
+        "      <td>Example|Event</td>\n" \
+        "    </tr>\n" \
+        "  </tbody>\n" \
+        "</table>"
+      ))
+    end
+
+    it "partially replaces incomplete markdown tables" do
+      subject.body =
+        "| Name       | Link         |<br>" \
+        "| ---------- | ------------ |<br>" \
+        "| Event-Name | {event-name}<br>"
+
+      expect(output).to include(trim(
+        "<table>\n" \
+        "  <thead>\n" \
+        "    <tr>\n" \
+        "      <th>Name</th>\n" \
+        "      <th>Link</th>\n" \
+        "    </tr>\n" \
+        "  </thead>\n" \
+        "  <tbody></tbody>\n" \
+        "</table>\n" \
+        "| Event-Name | Example|Event" \
+      ))
+    end
+
+    it "doesn't replace markdown tables with missing header" do
+      subject.body =
+        "| Name       | Link         |<br>" \
+        "| Event-Name | {event-name} |<br>"
+
+      expect(output).to include("| Event-Name | Example|Event |")
+      expect(output).not_to include("<table>")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1119

der regex matched `<br>`, weil die newlines im ui zu html converted werden