### PR TITLE
Do not update primary group explicitely in membership mutations

### DIFF
--- a/app/models/memberships/common_api.rb
+++ b/app/models/memberships/common_api.rb
@@ -79,14 +79,6 @@ module Memberships::CommonApi
       update_roles.each { |role| role.save(validate: false) }
       update_roles.each(&:save!)
     end
-    update_primary_groups
     true
-  end
-
-  def update_primary_groups
-    affected_people.each do |person|
-      person.reload # Unsure why this reload is necessary
-      person.update!(primary_group: Groups::Primary.new(person).identify)
-    end
   end
 end


### PR DESCRIPTION
fixes #1161

The primary group gets updated already in after_save/after_destroy
callbacks on Role, so we don't have to do it explicitely in the
membership mutations.

The previous implementation with `update!` naively assumed that the
updated people are valid, which is not necessarily the case so the user
got http 500 error responses.
For the membership mutation we should not care about person validity
unless it is a precondition for the mutation, then we should handle it
explicitely and should not try to update the primary group anyway.
