### PR TITLE
PeopleImporter: fix race condition, do not create duplicate additional_email

### DIFF
--- a/app/domain/sac_imports/people_importer.rb
+++ b/app/domain/sac_imports/people_importer.rb
@@ -31,10 +31,8 @@ module SacImports
         @output.print("Starting import from row with navision_id #{start_at_navision_id} (#{start_from_row[:last_name]} #{start_from_row[:first_name]})\n")
       end
 
-      Parallel.map(data, in_threads: 12) do |row|
+      data.each do |row|
         process_row(row)
-      rescue Exception # rubocop:disable Lint/RescueException we want to catch and re-raise all exceptions
-        raise Parallel::Break
       end
 
       @csv_report.finalize(output: @output)


### PR DESCRIPTION
Seit der Personenimport parallelisiert wurde, gibt es race conditions da wir im file mehrere Einträge haben mit gleicher 
* Email Adresse (Person mehrfach registriert)
* navision_id (Person war Mitglied von verschiedenen Familien)

Ausserdem wurden bei mehrfacher Ausführung des imports die Email Duplikate auch mehrfach als AdditionalEmail angelegt.

Des weiteren wurde ein case sensitive where verwendet beim lookup ob eine Email bereits von einer anderen Person verwendet wurde. Devise selber macht aber einen case insensitive search und markiert den record als invalid