### PR TITLE
Use sort_expression to reorder external invoices

### DIFF
--- a/app/controllers/people/external_invoices_controller.rb
+++ b/app/controllers/people/external_invoices_controller.rb
@@ -28,6 +28,7 @@ class People::ExternalInvoicesController < ListController
       .where(search_conditions)
       .where(person: person).list
 
+    scope = scope.reorder(sort_expression) if sorting?
     scope.page(params[:page]).per(50)
   end
 

--- a/app/controllers/people/external_invoices_controller.rb
+++ b/app/controllers/people/external_invoices_controller.rb
@@ -24,12 +24,10 @@ class People::ExternalInvoicesController < ListController
   private
 
   def list_entries
-    scope = ExternalInvoice
+    super.list
+      .where(person: person)
       .where(search_conditions)
-      .where(person: person).list
-
-    scope = scope.reorder(sort_expression) if sorting?
-    scope.page(params[:page]).per(50)
+      .page(params[:page]).per(50)
   end
 
   def person

--- a/app/views/people/external_invoices/_table.html.haml
+++ b/app/views/people/external_invoices/_table.html.haml
@@ -9,7 +9,7 @@
   = paginate @external_invoices
 
 = crud_table(data: { checkable: true }) do |t|
-  - t.col(t.sort_header(:title)) do |invoice|
+  - t.col(t.attr_header(:title)) do |invoice|
     %strong= invoice.title
   - t.sortable_attrs(:state, :abacus_sales_order_key, :total, :issued_at, :created_at, :updated_at)
   - t.col('') do |invoice|


### PR DESCRIPTION
This fixes all sortable colums besides the title, the problem is that our Searchable module is based on database sorting (ORDER BY), the sort_expression we get can't be used easily for title sorting, because title is a ruby Method that builds together the title.

Example for Membership Invoices
```
def title
    I18n.t("invoices.sac_memberships.title", year: year)
  end

```

First solution would be to not enable sorting in the table attrs for titles, if the invoices really have to be sortable by title, we have to consider adding the title as a database attribute, PostgreSQL offers generated columns, but we can only use other entity information in the expression, not I18n translations. 
