### PR TITLE
Reintroduce privacy_policy_acceptance_field

### DIFF
--- a/app/views/event/participation_contact_datas/_fields.html.haml
+++ b/app/views/event/participation_contact_datas/_fields.html.haml
@@ -17,5 +17,6 @@
     = ff.hidden_field(:public)
     = ff.hidden_field(:translated_label)
     = ff.hidden_field(:_destroy, value: false)
+= render('people/privacy_policy_acceptance_field', policy_finder: @policy_finder, f: f)
 
-.well=t('.overrides_person_data_info')
+.well.align-with-form=t('.overrides_person_data_info')

--- a/spec/views/event/participation_contact_datas/_fields.html.haml_spec.rb
+++ b/spec/views/event/participation_contact_datas/_fields.html.haml_spec.rb
@@ -9,11 +9,13 @@ describe "event/participation_contact_datas/_fields.html.haml" do
   include FormatHelper
 
   let(:participation_contact_data) { Event::ParticipationContactData.new(events(:top_course), people(:mitglied)) }
+  let(:policy_finder) { double(:policy_finder, acceptance_needed?: true, groups: []) }
   let(:form_builder) { StandardFormBuilder.new(:participation_contact_data, participation_contact_data, view, {}) }
 
   before do
     allow(form_builder).to receive(:fields_for).and_return([])
     allow(view).to receive_messages(f: form_builder, entry: participation_contact_data, phone_numbers: [])
+    assign(:policy_finder, policy_finder)
   end
 
   let(:dom) {


### PR DESCRIPTION
Lokal muss zum testen `acceptance_needed?` angepasst werden, damit diese Methode immer true zurück gibt, oder es muss eine Datenschutzerklärung in der Gruppe hochgeladen werden.