### PR TITLE
Override people/_fields_youth to remove AHV number field

### DIFF
--- a/app/views/people/_details_youth.html.haml
+++ b/app/views/people/_details_youth.html.haml
@@ -1,0 +1,10 @@
+- # Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+- # hitobito_sac_cas and licensed under the Affero General Public License version 3
+- # or later. See the COPYING file at the top-level directory or at
+- # https://github.com/hitobito/hitobito.
+
+- # Override the youth view to hide the AHV number.
+- # See https://github.com/hitobito/hitobito_sac_cas/issues/1346
+
+- if show_full
+  = render_attrs(entry, :j_s_number, :translated_nationality_j_s)

--- a/app/views/people/_fields_youth.html.haml
+++ b/app/views/people/_fields_youth.html.haml
@@ -1,0 +1,15 @@
+- # Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+- # hitobito_sac_cas and licensed under the Affero General Public License version 3
+- # or later. See the COPYING file at the top-level directory or at
+- # https://github.com/hitobito/hitobito.
+
+- # Override the youth view to hide the AHV number.
+- # See https://github.com/hitobito/hitobito_sac_cas/issues/1346
+
+= field_set_tag do
+  = f.labeled_input_fields(:j_s_number)
+  = f.labeled_collection_select(:nationality_j_s,
+                                Person::NATIONALITIES_J_S,
+                                :to_s, Proc.new { |n| t("activerecord.attributes.person.nationalities_j_s.#{n}") },
+                                { include_blank: "" },
+                                { class: 'form-select form-select-sm' })


### PR DESCRIPTION
Ref: #1346 

<details>
<summary>Profile View</summary>

![image](https://github.com/user-attachments/assets/b8101d7e-7c0b-4347-b424-7dc158d82f3a)

</details>


<details>
<summary>Edit View</summary>

![image](https://github.com/user-attachments/assets/04538b87-dafe-4197-a046-3c8e3e178875)


</details>