### PR TITLE
SacImports: NAV1 import additional phone numbers (HIT-58)

### DIFF
--- a/app/domain/sac_imports/csv_source.rb
+++ b/app/domain/sac_imports/csv_source.rb
@@ -59,9 +59,9 @@ class SacImports::CsvSource
   end
 
   def check_row_size(row)
-    expected_size = column_data_class.members.size
-    if row.size != expected_size
-      raise "#{@source_name}: wrong number of columns, got #{row.size} expected #{expected_size}"
+    valid_sizes = column_data_class.try(:valid_sizes) || [column_data_class.members.size]
+    unless valid_sizes.include?(row.size)
+      raise "#{@source_name}: wrong number of columns, got #{row.size} expected #{valid_sizes.join(" or ")}"
     end
   end
 

--- a/app/domain/sac_imports/csv_source/nav1.rb
+++ b/app/domain/sac_imports/csv_source/nav1.rb
@@ -21,7 +21,7 @@ class SacImports::CsvSource
     :town, # "City",
     :zip_code, # "Post Code",
     :email, # "E-Mail",
-    :phone, # "Phone No_",
+    :phone, # "Phone No_", -> Haupt-Telefon
     :birthday, # "Date of Birth",
     :gender, # "Geschlecht",
     :language, # "Language Code",
@@ -42,6 +42,18 @@ class SacImports::CsvSource
     :opt_in_sektionsbulletin_digital, # "OPT_IN_Sektionsbulletin_digital",
     :opt_out_sektionsbulletin_physisch, # "OPT_OUT_Sektionsbulletin_physisch",
     :opt_out_sektionsbulletin_digital, # "OPT_OUT_Sektionsbulletin_digital",
-    :termination_reason # "Austrittsgrund"
-  )
+    :termination_reason, # "Austrittsgrund"
+    :phone_private, # -> Privat
+    :phone_mobile, # -> Mobil
+    :phone_work # -> Geschäftlich
+  ) do
+    def initialize(phone_private: nil, phone_mobile: nil, phone_work: nil, **opts)
+      super
+    end
+
+    def self.valid_sizes
+      # it is valid with all columns or with all except the last three phone columns
+      [members.size, members.size - 3]
+    end
+  end
 end

--- a/spec/domain/sac_imports/csv_source/nav1_spec.rb
+++ b/spec/domain/sac_imports/csv_source/nav1_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require "spec_helper"
+
+describe SacImports::CsvSource::Nav1 do
+  let(:attrs) { described_class.members }
+  let(:row) { attrs.index_by(&:itself) }
+
+  subject(:data) { described_class.new(**row) }
+
+  it "works with all columns" do
+    attrs.each do |attr|
+      expect(data.send(attr)).to eq row[attr]
+    end
+  end
+
+  it "works without the last three phone columns" do
+    row.delete(:phone_private)
+    row.delete(:phone_mobile)
+    row.delete(:phone_work)
+
+    (attrs - [:phone_private, :phone_mobile, :phone_work]).each do |attr|
+      expect(data.send(attr)).to eq row[attr]
+    end
+    expect(data.phone_private).to be_nil
+    expect(data.phone_mobile).to be_nil
+    expect(data.phone_work).to be_nil
+  end
+end


### PR DESCRIPTION
* neues NAV1 file wird 3 Spalten mehr haben mit Telefonnummern (am Ende angehängt, die Spalten davor bleiben gleich)
* Importer kann mit altem und neuen file umgehen

Zitat Stefan
> Folgende 3 Spalten werden am Ende der Datei neu hinzugefügt (in genau dieser Reihenfolge):
> 
> -- Privat
> -- Mobil
> -- Geschäftlich
> 
> Bestehende Telefonnummer (Spalte #13) soll neu als Haupt-Telefon geladen werden.