### PR TITLE
SacImports: implement chimp importer (HIT-633)

### DIFF
--- a/app/domain/sac_imports/chimp_importer.rb
+++ b/app/domain/sac_imports/chimp_importer.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+module SacImports
+  class ChimpImporter
+    include LogCounts
+
+    REPORT_HEADERS = [
+      :email,
+      :first_name,
+      :last_name,
+      :status,
+      :warnings,
+      :errors
+    ].freeze
+
+    attr_reader :output
+
+    def initialize(output: $stdout)
+      @output = output
+      @csv_report = CsvReport.new(:"chimp-import", REPORT_HEADERS, output:)
+    end
+
+    def create
+      chimp_1 = CsvSource.new(:CHIMP_1)
+      chimp_2 = CsvSource.new(:CHIMP_2)
+      chimp_3 = CsvSource.new(:CHIMP_3)
+
+      list_newsletter = MailingList.find_by!(internal_key: SacCas::MAILING_LIST_SAC_NEWSLETTER_INTERNAL_KEY)
+      list_sac_inside = MailingList.find_by!(internal_key: SacCas::MAILING_LIST_SAC_INSIDE_INTERNAL_KEY)
+      list_tourenleiter = MailingList.find_by!(internal_key: SacCas::MAILING_LIST_TOURENLEITER_INTERNAL_KEY)
+
+      total_lines = [chimp_1, chimp_2, chimp_3].sum(&:lines_count)
+      progress = Progress.new(total_lines, title: "Mailchimp Subscriptions")
+
+      @csv_report.log("Chimp 1 (Newsletter) has #{chimp_1.lines_count} lines")
+      @csv_report.log("Chimp 2 (SAC Inside) has #{chimp_2.lines_count} lines")
+      @csv_report.log("Chimp 3 (Tourenleiter) has #{chimp_3.lines_count} lines")
+      @csv_report.log("Total lines: #{total_lines}")
+
+      log_counts_delta(@csv_report,
+        "Newsletter Subscribers" => list_newsletter.subscriptions.where(subscriber_type: "Person"),
+        "SAC Inside Subscribers" => list_sac_inside.subscriptions.where(subscriber_type: "Person"),
+        "Tourenleiter Subscribers" => list_tourenleiter.subscriptions.where(subscriber_type: "Person")) do
+        import_subscribers(chimp_1, list_newsletter, progress)
+        import_subscribers(chimp_2, list_sac_inside, progress)
+        import_subscribers(chimp_3, list_tourenleiter, progress)
+      end
+    end
+
+    private
+
+    def import_subscribers(source, list, progress)
+      report = CsvReport.new(source.source_name.to_s.downcase, REPORT_HEADERS, output: @output)
+
+      source.rows do |row|
+        progress.step
+        email = row.email.downcase
+
+        person = Person.find_by(email: email)
+
+        next report_unknown_email(report, row) if person.nil?
+
+        list.subscriptions.where(subscriber: person).first_or_create!
+      end
+    end
+
+    def report_unknown_email(report, row)
+      report.add_row({
+        email: row.email,
+        first_name: row.first_name,
+        last_name: row.last_name,
+        status: "error",
+        errors: "Person with email not found"
+      })
+    end
+  end
+end

--- a/app/domain/sac_imports/csv_source.rb
+++ b/app/domain/sac_imports/csv_source.rb
@@ -16,10 +16,15 @@ class SacImports::CsvSource
     NAV3: Nav3,
     NAV6: Nav6,
     NAV17: Nav17,
-    WSO21: Wso2
+    WSO21: Wso2,
+    CHIMP_1: Chimp,
+    CHIMP_2: Chimp,
+    CHIMP_3: Chimp
   }.freeze
 
   AVAILABLE_SOURCES = SOURCES.keys.freeze
+
+  attr_reader :source_name
 
   def initialize(source_name, source_dir: SOURCE_DIR)
     @source_dir = source_dir

--- a/app/domain/sac_imports/csv_source/chimp.rb
+++ b/app/domain/sac_imports/csv_source/chimp.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+class SacImports::CsvSource
+  Chimp = Data.define(:email, :first_name, :last_name, :source)
+end

--- a/lib/tasks/sac_imports.rake
+++ b/lib/tasks/sac_imports.rake
@@ -68,6 +68,7 @@ namespace :sac_imports do
     "wso21-1_people",
     "nav2b-2_non_membership_roles",
     "nav1-3_subscriptions",
+    "chimp-subscriptions",
     :update_sac_family_address,
     "nav17-1_event_kinds",
     :cleanup,
@@ -158,6 +159,12 @@ namespace :sac_imports do
   task "nav17-1_event_kinds": :setup do
     SacImports::Nav17EventKindsImporter.new.create
     Rake::Task["sac_imports:dump_database"].execute(dump_name: "nav17-event-kinds")
+  end
+
+  desc "NAV1 Imports subscriptions from Navision"
+  task "chimp-subscriptions": :setup do
+    SacImports::ChimpImporter.new.create
+    Rake::Task["sac_imports:dump_database"].execute(dump_name: "chimp-subscriptions")
   end
 
   desc "Run cleanup tasks"


### PR DESCRIPTION
import subscribers from all chimp files
* try to find person by email, add subscription (list is opt-in, just blindly create sub if not exists yet without any further logic)
* if not found, log to report

@amaierhofer hier die Resultate meines Import Laufs:

```plain
Chimp 1 (Newsletter) has 51382 lines
Chimp 2 (SAC Inside) has 3039 lines
Chimp 3 (Tourenleiter) has 3566 lines

Type                     |Before|After|Delta
--------------------------------------------
Newsletter Subscribers   |     0|39040|39040
SAC Inside Subscribers   |     0| 1416| 1416
Tourenleiter Subscribers |     0| 3533| 3533
--------------------------------------------
```
* für Newsletter wurden für ~80% der subscriber die Person gefunden
* für SAC Inside für ~50%
* für Tourenleiter fast alle

z.T. melden sich die Personen ja direkt über Mailchimp an, daher ist zu erwarten, dass wir nicht alle kennen.
Bitte die Zahlen für einen sanity check noch mit Stefan besprechen und selber auch noch einen Testimport machen