### PR TITLE
SacImports: WSO2 log uuid -> hitobito id mapping

### DIFF
--- a/app/domain/sac_imports/csv_source/wso2.rb
+++ b/app/domain/sac_imports/csv_source/wso2.rb
@@ -10,7 +10,7 @@ class SacImports::CsvSource
   # they must match the order of the columns in the CSV files
   Wso2 = Data.define(
     :um_id, # "UM_ID",
-    :_um_user_name, # "UM_USER_NAME",
+    :um_user_name, # "UM_USER_NAME",
     :wso2_legacy_password_hash, # "UM_USER_PASSWORD",
     :wso2_legacy_password_salt, # "UM_SALT_VALUE",
     :_um_changed_time, # "UM_CHANGED_TIME",

--- a/app/domain/sac_imports/wso2/person_entry.rb
+++ b/app/domain/sac_imports/wso2/person_entry.rb
@@ -121,7 +121,7 @@ module SacImports::Wso2
       person.birthday = row.birthday
       person.gender = gender
       person.language = language
-      build_phone_number(person, :phone, "Hauptnummer")
+      build_phone_number(person, :phone, "Haupt-Telefon")
       build_phone_number(person, :phone_business, "Arbeit")
     end
 

--- a/spec/domain/sac_imports/wso2/person_entry_spec.rb
+++ b/spec/domain/sac_imports/wso2/person_entry_spec.rb
@@ -287,7 +287,7 @@ describe SacImports::Wso2::PersonEntry do
             row[:phone] = "invalid"
             expect(entry.person.phone_numbers.map(&:number)).to eq [row[:phone_business]]
             expect(entry.person.notes.map(&:text)).to eq [
-              "Importiert mit ungültiger Telefonnummer Hauptnummer: 'invalid'"
+              "Importiert mit ungültiger Telefonnummer Haupt-Telefon: 'invalid'"
             ]
           end
         end


### PR DESCRIPTION
@amaierhofer der wso2 import soll ein zusätzliches log file schreiben mit dem mapping von wso2 uuid -> hitobito id.
Das ist so mit agu abgesprochen.

output: 
```plain
hitobito_id;um_user_name
123456;000064d4-d3d6-4376-a4d5-075b85123456
```

(Dabei habe ich noch entdeckt, dass das label für die Telefonnummer nicht dem vordefinierten label entspricht -> angepasst)