### PR TITLE
Feature/1455/summon email when maunually summoning (#1455)

### DIFF
--- a/app/controllers/sac_cas/event/participations_controller.rb
+++ b/app/controllers/sac_cas/event/participations_controller.rb
@@ -17,7 +17,7 @@ module SacCas::Event::ParticipationsController
 
     around_create :proceed_wizard
     after_create :subscribe_newsletter
-    after_summon :enqueue_invoice_job
+    after_summon :enqueue_invoice_job, :send_summon_email
     after_assign :enqueue_confirmation_job # send_confirmation_email in core checks current_user_interested_in_mail? which should be irrelevant here
     before_cancel :assert_participant_cancelable?
     after_cancel :cancel_invoices
@@ -174,6 +174,10 @@ module SacCas::Event::ParticipationsController
 
   def enqueue_invoice_job
     ExternalInvoice::CourseParticipation.invoice!(entry) unless ExternalInvoice::CourseParticipation.exists?(link: entry)
+  end
+
+  def send_summon_email
+    Event::ParticipationMailer.summon(entry).deliver_later
   end
 
   def cancel_invoices

--- a/spec/controllers/event/participations_controller_spec.rb
+++ b/spec/controllers/event/participations_controller_spec.rb
@@ -406,7 +406,8 @@ describe Event::ParticipationsController do
 
     it "PUT#summon sets participation active and state to summoned" do
       expect { put :summon, params: params }
-        .not_to change(Delayed::Job.where("handler LIKE '%CreateCourseInvoiceJob%'"), :count)
+        .to have_enqueued_mail(Event::ParticipationMailer, :summon).once
+        .and change(Delayed::Job.where("handler LIKE '%CreateCourseInvoiceJob%'"), :count).by(0)
       expect(participation.reload.active).to be true
       expect(participation.state).to eq "summoned"
       expect(flash[:notice]).to match(/wurde aufgeboten/)


### PR DESCRIPTION
Gibt es einen Grund nicht ein `after_update` auf dem Participation Model zu verwenden, ähnlich zu den Event States? Aktuell implementieren wir an verschiedenen Orten das verschicken dieser Mails, gibt es einen bestimmten Grund dafür, weil der Status wird immer auf `:summon` gesetzt. Ich finde auf die Schnelle auch keine anderen Orte wo wir den Status auf `:summon` setzen und keine Email verschickt werden sollte.

Das gleiche Problem/Frage kam auch bei https://github.com/hitobito/hitobito_sac_cas/issues/1389 auf... wo wir die Anmeldebestätigungs-Mail mal über den Controller, ein anderes mal beim assignen über Application Market verschicken, obwohl beide Actions den Status der Participation einfach auf "Bestätigt" setzen. Auch dort bin ich mir jedoch nicht sicher ob es weitere Orte gibt, bei welchem keine Email verschickt werden sollte.