### PR TITLE
Fix email not knowing old section when terminating now

### DIFF
--- a/app/models/wizards/memberships/terminate_sac_membership_wizard.rb
+++ b/app/models/wizards/memberships/terminate_sac_membership_wizard.rb
@@ -65,7 +65,9 @@ module Wizards::Memberships
       end
     end
 
-    def role = @role ||= person.sac_membership.stammsektion_role
+    def role
+      @role ||= person.sac_membership.stammsektion_role
+    end
 
     def mitglied_termination_by_section_only?
       sektion&.mitglied_termination_by_section_only ||

--- a/app/models/wizards/memberships/terminate_sac_membership_wizard.rb
+++ b/app/models/wizards/memberships/terminate_sac_membership_wizard.rb
@@ -65,7 +65,7 @@ module Wizards::Memberships
       end
     end
 
-    def role = person.sac_membership.stammsektion_role
+    def role = @role ||= person.sac_membership.stammsektion_role
 
     def mitglied_termination_by_section_only?
       sektion&.mitglied_termination_by_section_only ||

--- a/spec/models/wizards/memberships/terminate_sac_membership_wizard_spec.rb
+++ b/spec/models/wizards/memberships/terminate_sac_membership_wizard_spec.rb
@@ -114,6 +114,23 @@ describe Wizards::Memberships::TerminateSacMembershipWizard do
           wizard.save!
         end.to change { role.reload.terminated }.from(false).to(true)
           .and change { role.end_on }.from(end_of_year).to(Date.yesterday)
+          .and have_enqueued_mail(Memberships::TerminateMembershipMailer, :terminate_membership).with(person, bluemlisalp, I18n.l(Date.yesterday))
+      end
+    end
+
+    context "role already terminated" do
+      let(:backoffice) { true }
+      let(:current_step) { 1 }
+
+      before do
+        role.update_column(:terminated, true)
+        params[:termination_choose_date] = {terminate_on: "now"}
+      end
+
+      it "does deliver TerminateSacMembership::terminate_membership email" do
+        expect do
+          wizard.save!
+        end.to have_enqueued_mail(Memberships::TerminateMembershipMailer, :terminate_membership).with(person, bluemlisalp, I18n.l(Date.yesterday))
       end
     end
   end

--- a/spec/views/wizards/steps/_termination_choose_date.html.haml_spec.rb
+++ b/spec/views/wizards/steps/_termination_choose_date.html.haml_spec.rb
@@ -23,6 +23,7 @@ describe "wizards/steps/_termination_choose_date.html.haml" do
     allow_any_instance_of(StepsComponent::ContentComponent).to receive(:fields_for).and_return([])
     allow(view).to receive_messages(c: steps_component)
     allow(view).to receive_messages(wizard: wizard)
+    wizard.instance_variable_set(:@role, nil)
   end
 
   it "renders warning when role is already terminated" do


### PR DESCRIPTION
Sentry Issue: https://sentry.puzzle.ch/pitc/hitobito-backend/issues/74127 und https://sentry.puzzle.ch/pitc/hitobito-backend/issues/74126

To recreate Problem, terminate a stammsektion role with
(any stammsektion role).update_column(:terminated, true)

Then just click Mitgliedschaft anpassen and SAC Mitgliedschaft beenden, choose "now" and finish the wizard steps, it will throw an error and not send the email without the fix