### PR TITLE
Implement phone number changes (#1563)

### DIFF
--- a/app/controllers/concerns/assigns_sac_phone_numbers.rb
+++ b/app/controllers/concerns/assigns_sac_phone_numbers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+module AssignsSacPhoneNumbers
+  extend ActiveSupport::Concern
+
+  private
+
+  def assign_attributes
+    super
+    mark_phone_numbers_for_destroy(entry) if action_name == "update"
+  end
+
+  # Mark phone numbers for destruction if they have an empty number field.
+  # This allows removing phone numbers by clearing the number field in the form.
+  def mark_phone_numbers_for_destroy(contactable)
+    PhoneNumber.predefined_labels.each do |label|
+      phone_number_assoc = :"phone_number_#{label}"
+      phone_number_params = model_params[:"#{phone_number_assoc}_attributes"]
+
+      if phone_number_params && phone_number_params[:number].blank?
+        contactable.send(phone_number_assoc)&.mark_for_destruction
+      end
+    end
+  end
+end

--- a/app/controllers/sac_cas/groups_controller.rb
+++ b/app/controllers/sac_cas/groups_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+module SacCas::GroupsController
+  extend ActiveSupport::Concern
+  prepend AssignsSacPhoneNumbers
+end

--- a/app/controllers/sac_cas/people_controller.rb
+++ b/app/controllers/sac_cas/people_controller.rb
@@ -7,6 +7,7 @@
 
 module SacCas::PeopleController
   extend ActiveSupport::Concern
+  prepend AssignsSacPhoneNumbers
 
   LOOKUP_PREFIX = "people/neuanmeldungen"
 

--- a/app/domain/export/tabular/people/sac_mitglied_row.rb
+++ b/app/domain/export/tabular/people/sac_mitglied_row.rb
@@ -111,14 +111,9 @@ module Export::Tabular::People
       group.navision_id_padded
     end
 
-    # Beliebige Telefonnummer mit dem angegebenen Label.
-    def phone_number(label)
-      entry.phone_numbers.find { |p| p.label.downcase == label.to_s }&.number
-    end
+    def phone_number_landline = entry.phone_number_landline&.number
 
-    def phone_number_main
-      phone_number("haupt-telefon")
-    end
+    def phone_number_mobile = entry.phone_number_mobile&.number
 
     def postfach
       entry.postbox
@@ -143,14 +138,6 @@ module Export::Tabular::People
     # Used for empty cells.
     def empty
       nil
-    end
-
-    def method_missing(method, *args)
-      (method.to_s =~ /^phone_number_(\w+)$/) ? phone_number(::Regexp.last_match(1)) : super
-    end
-
-    def respond_to_missing?(method, include_private = false)
-      method.to_s.start_with?("phone_number_") || super
     end
 
     private

--- a/app/domain/export/tabular/people/sac_mitglieder.rb
+++ b/app/domain/export/tabular/people/sac_mitglieder.rb
@@ -33,11 +33,11 @@ module Export::Tabular::People
         :town,
         :country,
         :birthday,
-        :phone_number_main,
-        :phone_number_privat,
         :empty, # 1 leere Spalte
-        :phone_number_mobil,
-        :phone_number_fax,
+        :phone_number_landline,
+        :empty, # 1 leere Spalte
+        :phone_number_mobile,
+        :empty, # 1 leere Spalte
         :email,
         :gender,
         :empty, # 1 leere Spalte
@@ -68,7 +68,7 @@ module Export::Tabular::People
           type: SacCas::MITGLIED_ROLES.map(&:sti_name)
         })
         .joins(:roles)
-        .includes(:phone_numbers, :roles_unscoped, roles: :group)
+        .includes(:phone_number_landline, :phone_number_mobile, :roles_unscoped, roles: :group)
         .distinct
     end
 

--- a/app/domain/sac_cas.rb
+++ b/app/domain/sac_cas.rb
@@ -112,15 +112,20 @@ module SacCas
     .select { |c| c.to_s =~ /MAILING_LIST_.*INTERNAL_KEY/ }
     .map { |c| const_get(c) }
 
-  MEMBERSHIP_OPERATIONS_GROUP_TYPES = [::Group::Sektion.sti_name, ::Group::Ortsgruppe.sti_name].freeze
+  AboCost = Data.define(:amount, :country)
+  ABO_COSTS = {
+    magazin: [
+      AboCost.new(amount: 60, country: :switzerland),
+      AboCost.new(amount: 76, country: :international)
+    ],
+    tourenportal: [
+      AboCost.new(amount: 45, country: nil)
+    ]
+  }
+
+  MEMBERSHIP_OPERATIONS_GROUP_TYPES = %w[Group::Sektion Group::Ortsgruppe].freeze
   MEMBERSHIP_OPERATIONS_EXCLUDED_IDS = [
     2900, 3700, 2249, 2330, 2601, 3030, 3251,
     3730, 3952, 3953, 3954, 4530, 4851, 5401
   ]
-
-  def main_phone_label
-    Settings.phone_number.predefined_labels.find { |l| l =~ /Haupt/ }
-  end
-
-  module_function :main_phone_label
 end

--- a/app/domain/sac_cas/oidc_claim_setup.rb
+++ b/app/domain/sac_cas/oidc_claim_setup.rb
@@ -43,9 +43,12 @@ module SacCas::OidcClaimSetup
   def run
     super
 
-    add_claim(:picture_url, scope: [:name, :with_roles])
-    add_claim(:membership_verify_url, scope: [:name, :with_roles])
-    add_claim(:phone, scope: [:name, :with_roles])
+    with_options(scope: [:name, :with_roles]) do
+      add_claim(:picture_url)
+      add_claim(:membership_verify_url)
+      add_claim(:phone_number_landline)
+      add_claim(:phone_number_mobile)
+    end
 
     add_claim(:membership_years, scope: :with_roles)
     add_claim(:user_groups, scope: :user_groups)
@@ -61,9 +64,9 @@ module SacCas::OidcClaimSetup
     People::Membership::VerificationQrCode.new(owner).verify_url if owner.sac_membership_anytime?
   end
 
-  def phone(owner)
-    owner.phone_numbers.order(:id).find_by(label: SacCas.main_phone_label)&.number
-  end
+  def phone_number_landline(owner) = owner.phone_number_landline&.number
+
+  def phone_number_mobile(owner) = owner.phone_number_mobile&.number
 
   def membership_years(owner)
     owner.membership_years

--- a/app/models/concerns/sac_phone_numbers.rb
+++ b/app/models/concerns/sac_phone_numbers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+# In the sac wagon, we allow only a predefined set of phone numbers with their distinct label.
+# For those we always show the form fields, even if the records don't exist yet.
+# To simplify the form handling, we define a `has_one` association for each predefined number.
+module SacPhoneNumbers
+  def self.prepended(base)
+    PhoneNumber.predefined_labels.each do |label|
+      phone_number_assoc = :"phone_number_#{label}"
+      # rubocop:disable Rails/HasManyOrHasOneDependent (handled on has_many :phone_numbers)
+      # rubocop:disable Rails/InverseOf (association not defined on opposite side)
+      base.has_one phone_number_assoc, -> { where(label: label) },
+        class_name: "PhoneNumber", as: :contactable
+      # rubocop:enable Rails/HasManyOrHasOneDependent, Rails/InverseOf
+
+      base.accepts_nested_attributes_for phone_number_assoc, allow_destroy: true
+    end
+  end
+end

--- a/app/models/sac_cas/phone_number.rb
+++ b/app/models/sac_cas/phone_number.rb
@@ -11,6 +11,11 @@ module SacCas::PhoneNumber
   included do
     after_create :check_data_quality
     after_destroy :check_data_quality
+
+    validates :label,
+      inclusion: {in: PhoneNumber.predefined_labels},
+      uniqueness: {scope: [:contactable_type, :contactable_id]},
+      allow_blank: false
   end
 
   private

--- a/app/models/wizards/steps/signup/person_common.rb
+++ b/app/models/wizards/steps/signup/person_common.rb
@@ -8,7 +8,7 @@
 module Wizards::Steps::Signup::PersonCommon
   extend ActiveSupport::Concern
 
-  PHONE_NUMBER_LABEL = "Mobil"
+  PHONE_NUMBER_LABEL = "mobile"
 
   included do
     class_attribute :minimum_age, default: SacCas::Beitragskategorie::Calculator::AGE_RANGE_MINOR_FAMILY_MEMBER.begin
@@ -35,7 +35,7 @@ module Wizards::Steps::Signup::PersonCommon
     attributes.compact.symbolize_keys.except(:phone_number).then do |attrs|
       next attrs if phone_number.blank?
 
-      attrs.merge(phone_numbers_attributes: [{label: PHONE_NUMBER_LABEL, number: phone_number, id: phone_number_id}.compact])
+      attrs.merge(phone_number_mobile_attributes: {number: phone_number, id: phone_number_id})
     end
   end
 

--- a/app/views/contactable/_phone_number_fields.html.haml
+++ b/app/views/contactable/_phone_number_fields.html.haml
@@ -7,4 +7,4 @@
   %div.col-11.col-md-5.me-3.mb-1
     = f.input_field(:number, placeholder: PhoneNumber.human_attribute_name(:number))
   %div.col-11.col-md-4.d-flex.flex-row.me-3
-    = f.object.translated_label
+    = f.label(:number, f.object.translated_label)

--- a/app/views/contactable/_phone_number_fields.html.haml
+++ b/app/views/contactable/_phone_number_fields.html.haml
@@ -1,0 +1,10 @@
+- #  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+- #  hitobito_sac_cas and licensed under the Affero General Public License version 3
+- #  or later. See the COPYING file at the top-level directory or at
+- #  https://github.com/hitobito/hitobito_sac_cas.
+
+%div.d-flex.flex-wrap.w-100.align-items-center
+  %div.col-11.col-md-5.me-3.mb-1
+    = f.input_field(:number, placeholder: PhoneNumber.human_attribute_name(:number))
+  %div.col-11.col-md-4.d-flex.flex-row.me-3
+    = f.object.translated_label

--- a/app/views/contactable/_phone_numbers_fields.html.haml
+++ b/app/views/contactable/_phone_numbers_fields.html.haml
@@ -1,0 +1,11 @@
+- #  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+- #  hitobito_sac_cas and licensed under the Affero General Public License version 3
+- #  or later. See the COPYING file at the top-level directory or at
+- #  https://github.com/hitobito/hitobito_sac_cas.
+
+= f.labeled :phone_numbers do
+  - PhoneNumber.predefined_labels.each do |label|
+    - assoc = "phone_number_#{label}"
+    - number = entry.send(assoc) || entry.send("build_#{assoc}")
+    = f.fields_for assoc, number do |fields|
+      - render 'contactable/phone_number_fields', f: fields

--- a/app/views/event/participation_contact_datas/_fields.html.haml
+++ b/app/views/event/participation_contact_datas/_fields.html.haml
@@ -10,13 +10,7 @@
 = f.labeled_input_fields :first_name, :last_name, :email
 = f.labeled_date_field :birthday
 = render 'contactable/address_fields', f: f
-- phone_number = entry.phone_numbers.first || PhoneNumber.new(label: 'Mobile', public: true)
-= f.fields_for(:phone_numbers, phone_number) do |ff|
-  = ff.labeled(:number, Wizards::Steps::Signup::PersonFields.human_attribute_name(:phone_number)) do
-    = ff.input_field(:number)
-    = ff.hidden_field(:public)
-    = ff.hidden_field(:translated_label)
-    = ff.hidden_field(:_destroy, value: false)
+= render 'contactable/phone_numbers_fields', f: f
 = render('people/privacy_policy_acceptance_field', policy_finder: @policy_finder, f: f)
 
 .well.align-with-form=t('.overrides_person_data_info')

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -187,15 +187,8 @@ de:
     attributes:
       contact_account:
         predefined_labels:
-          andere: Andere
-          arbeit: Arbeit
-          fax: Fax
-          "haupt-telefon": Haupt-Telefon
-          mobil: Mobil
-          mutter: Mutter
-          privat: Privat
-          vater: Vater
-          webseite: Webseite
+          landline: Festnetz
+          mobile: Mobil
       cost_center:
         label: Bezeichnung
         event_kind_categories: Kurskategorien
@@ -407,6 +400,10 @@ de:
           m: Herr
           w: Frau
         additional_information: Bemerkungen (z.B. Beruf)
+      person/phone_number_mobile:
+        number: Mobiltelefon
+      person/phone_number_landline:
+        number: Festnetztelefon
       group:
         type: Gruppentyp technisch
         group_id: Gruppen-ID

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,14 +67,9 @@ social_account:
 
 phone_number:
   predefined_labels:
-    - Haupt-Telefon
-    - Privat
-    - Mobil
-    - Arbeit
-    - Vater
-    - Mutter
-    - Fax
-    - Andere
+    - --
+    - landline
+    - mobile
 
 impersonate:
   notify: false

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -63,12 +63,14 @@ module HitobitoSacCas
       Event::ParticipationMailer.prepend SacCas::Event::ParticipationMailer
       Event::Participation.prepend SacCas::Event::Participation
       Event::Answer.include SacCas::Event::Answer
+      Group.prepend SacPhoneNumbers
       Group.include SacCas::Group
       Household.prepend SacCas::Household
       HouseholdMember.prepend SacCas::HouseholdMember
       Households::MemberValidator.prepend SacCas::Households::MemberValidator
       MailingList.include SacCas::MailingList
       Person.prepend SacCas::Person
+      Person.prepend SacPhoneNumbers
       Person::Address.prepend SacCas::Person::Address
       People::Membership::Verifier.prepend SacCas::People::Membership::Verifier
       PeopleManager.prepend SacCas::PeopleManager
@@ -78,6 +80,11 @@ module HitobitoSacCas
       Qualification.include SacCas::Qualification
       QualificationKind.include SacCas::QualificationKind
       Contactable.prepend SacCas::Contactable
+      PhoneNumber.predefined_labels.each do |label|
+        PeopleController.permitted_attrs << {"phone_number_#{label}_attributes": [:id, :number]}
+        GroupsController.permitted_attrs << {"phone_number_#{label}_attributes": [:id, :number]}
+      end
+
       Wizards::Steps::NewUserForm.support_company = false
 
       HouseholdAsideComponent.prepend SacCas::HouseholdAsideComponent
@@ -171,6 +178,7 @@ module HitobitoSacCas
       Event::RolesController.prepend SacCas::Event::RolesController
       GroupsController.permitted_attrs << :mitglied_termination_by_section_only
       GroupsController.permitted_attrs << {section_offering_ids: []}
+      GroupsController.prepend SacCas::GroupsController
       Groups::SelfRegistrationController.prepend SacCas::Groups::SelfRegistrationController
       Groups::SelfInscriptionController.prepend SacCas::Groups::SelfInscriptionController
       JsonApi::EventsController.prepend SacCas::JsonApi::EventsController

--- a/spec/controllers/event/participation_contact_datas_controller_spec.rb
+++ b/spec/controllers/event/participation_contact_datas_controller_spec.rb
@@ -38,7 +38,7 @@ describe Event::ParticipationContactDatasController do
 
     it "stores attributes on person if valid" do
       course.update(required_contact_attrs: %w[phone_numbers])
-      number = person.phone_numbers.create!(label: "dummy", number: "+41790000000")
+      number = person.create_phone_number_mobile!(label: "mobile", number: "+41790000000")
       patch :update, params: {
         group_id: group.id,
         event_id: course.id,
@@ -53,8 +53,9 @@ describe Event::ParticipationContactDatasController do
           town: "Zürich",
           country: "CH",
           last_name: "NewName",
-          phone_numbers_attributes: {
-            "1" => {id: number.id, label: number.label, number: "+41791111111", _destroy: false}
+          phone_number_mobile_attributes: {
+            id: number.id,
+            number: "+41791111111"
           }
         },
         event_role: {

--- a/spec/controllers/event/register_controller_spec.rb
+++ b/spec/controllers/event/register_controller_spec.rb
@@ -32,12 +32,8 @@ describe Event::RegisterController do
       town: "Zürich",
       country: "CH",
       birthday: "01.01.1980",
-      phone_numbers_attributes: {
-        "0": {
-          number: "+41 79 123 45 56",
-          public: true,
-          translated_label: "Mobile"
-        }
+      phone_number_mobile_attributes: {
+        number: "+41 79 123 45 56"
       }
     }.with_indifferent_access
   }
@@ -60,6 +56,16 @@ describe Event::RegisterController do
         expect(person.roles.first.type).to eq(Group::AboBasicLogin::BasicLogin.sti_name)
         is_expected.to redirect_to(new_group_event_participation_path(group, event))
         expect(flash[:notice]).to include "Deine persönlichen Daten wurden aufgenommen. Bitte ergänze nun noch die Angaben"
+      end
+    end
+
+    context "without any phone number" do
+      it "does not create person" do
+        attrs.delete(:phone_number_mobile_attributes)
+
+        expect do
+          put :register, params: {group_id: group.id, id: event.id, event_participation_contact_data: attrs}
+        end.not_to change { Person.count }
       end
     end
   end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require "spec_helper"
+
+describe GroupsController do
+  before { sign_in(people(:admin)) }
+
+  let(:group) { groups(:bluemlisalp) }
+
+  context "PUT#update" do
+    it "can update phone_numbers" do
+      expect do
+        put :update, params: {id: group.id,
+                              group: {
+                                phone_number_landline_attributes: {number: "+41 77 123 45 66"},
+                                phone_number_mobile_attributes: {number: "+41 77 123 45 67"}
+                              }}
+      end.to change { group.reload.phone_numbers.count }.by(2)
+        .and change { group.phone_number_landline&.number }.to("+41 77 123 45 66")
+        .and change { group.phone_number_mobile&.number }.to("+41 77 123 45 67")
+    end
+
+    it "can remove phone_numbers" do
+      group.create_phone_number_landline(number: "+41 77 123 45 66")
+
+      expect do
+        put :update, params: {id: group.id,
+                              group: {
+                                phone_number_landline_attributes: {
+                                  id: group.phone_number_landline.id,
+                                  number: ""
+                                }
+                              }}
+      end.to change { group.reload.phone_numbers.count }.by(-1)
+        .and change { group.phone_number_landline&.number }.from("+41 77 123 45 66").to(nil)
+    end
+  end
+end

--- a/spec/controllers/oauth/userinfo_controller_spec.rb
+++ b/spec/controllers/oauth/userinfo_controller_spec.rb
@@ -40,7 +40,8 @@ describe Doorkeeper::OpenidConnect::UserinfoController do
           zip_code: user.zip_code,
           town: user.town,
           country: user.country,
-          phone: nil,
+          phone_number_landline: nil,
+          phone_number_mobile: nil,
           picture_url: %r{packs(-test)?/media/images/profile-.*\.svg},
           membership_verify_url: nil
         }.deep_stringify_keys)
@@ -95,7 +96,8 @@ describe Doorkeeper::OpenidConnect::UserinfoController do
           birthday: user.birthday.to_s.presence,
           primary_group_id: user.primary_group_id,
           language: user.language,
-          phone: nil,
+          phone_number_landline: nil,
+          phone_number_mobile: nil,
           membership_years: 0,
           picture_url: %r{packs(-test)?/media/images/profile-.*\.svg},
           membership_verify_url: nil,

--- a/spec/domain/export/tabular/people/sac_mitglied_row_spec.rb
+++ b/spec/domain/export/tabular/people/sac_mitglied_row_spec.rb
@@ -261,20 +261,14 @@ describe Export::Tabular::People::SacMitgliedRow do
     expect(row.layer_navision_id_padded).to eq(group.navision_id_padded)
   end
 
-  it "#phone_number returns any number for given label" do
-    mobile1 = Fabricate(:phone_number, contactable: person, label: "mobile", number: "0781234567")
-    mobile2 = Fabricate(:phone_number, contactable: person, label: "mobile", number: "0782345678")
-    expect(row.phone_number("mobile")).to eq(mobile1.number).or eq(mobile2.number)
-  end
-
-  it "#phone_number_main returns number with label Haupt-Telefon" do
-    main = Fabricate(:phone_number, contactable: person, label: "Haupt-Telefon", number: "0311234567")
-    expect(row.phone_number_main).to eq main.number
+  it "#phone_number_landline returns number with label landline" do
+    main = Fabricate(:phone_number, contactable: person, label: "landline", number: "0311234567")
+    expect(row.fetch(:phone_number_landline)).to eq main.number
   end
 
   it "#phone_number_mobile returns any number with label mobile" do
     mobile = Fabricate(:phone_number, contactable: person, label: "mobile", number: "0781234567")
-    expect(row.phone_number_mobile).to eq mobile.number
+    expect(row.fetch(:phone_number_mobile)).to eq mobile.number
   end
 
   it "#postfach returns postbox for now" do

--- a/spec/domain/export/tabular/people/sac_mitglieder_spec.rb
+++ b/spec/domain/export/tabular/people/sac_mitglieder_spec.rb
@@ -38,11 +38,11 @@ describe Export::Tabular::People::SacMitglieder do
         :town,
         :country,
         :birthday,
-        :phone_number_main,
-        :phone_number_privat,
         :empty, # 1 leere Spalte
-        :phone_number_mobil,
-        :phone_number_fax,
+        :phone_number_landline,
+        :empty, # 1 leere Spalte
+        :phone_number_mobile,
+        :empty, # 1 leere Spalte
         :email,
         :gender,
         :empty, # 1 leere Spalte
@@ -131,14 +131,15 @@ describe Export::Tabular::People::SacMitglieder do
       # - 1 for loading the group
       # - 1 for loading the groups children
       # - 1 for loading all people
-      # - 1 for loading their phone numbers
+      # - 1 for loading phone_number_landline
+      # - 1 for loading phone_number_mobile
       # - 1 for loading the people's roles_unscoped
       # - 1 for loading the people's roles
       # - 1 for loading the people's roles' groups
       expect_query_count do
         # make sure we have more than one row for the test to be meaningful
         expect(tabular.data_rows.to_a).to have_at_least(2).items
-      end.to eq 7
+      end.to eq 8
     end
   end
 end

--- a/spec/domain/oidc_claim_setup_spec.rb
+++ b/spec/domain/oidc_claim_setup_spec.rb
@@ -22,14 +22,17 @@ describe OidcClaimSetup do
 
   shared_examples "shared claims" do
     describe "phone" do
-      it "is blank when no matching number exists" do
-        expect(claim_keys).to include("phone")
+      it "is blank when no number exists" do
+        expect(claims).to include(phone_number_mobile: nil)
+        expect(claims).to include(phone_number_landline: nil)
       end
 
-      it "returns first number with matching label" do
-        owner.phone_numbers.create!(label: "Haupt-Telefon", number: "0791234560")
-        owner.phone_numbers.create!(label: "Haupt-Telefon", number: "0791234561")
-        expect(claims[:phone]).to eq "+41 79 123 45 60"
+      it "returns number with matching label" do
+        owner.phone_numbers.create!(label: "mobile", number: "0791234560")
+        owner.phone_numbers.create!(label: "landline", number: "0311234560")
+
+        expect(claims[:phone_number_mobile]).to eq "+41 79 123 45 60"
+        expect(claims[:phone_number_landline]).to eq "+41 31 123 45 60"
       end
     end
   end

--- a/spec/features/event/sign_up_spec.rb
+++ b/spec/features/event/sign_up_spec.rb
@@ -18,7 +18,8 @@ describe "Event Signup", :js do
     fill_in "event_participation_contact_data_street", with: "Musterplatz"
     fill_in "event_participation_contact_data_housenumber", with: "42"
     fill_in "Geburtsdatum", with: "01.01.1980"
-    fill_in "Telefon", with: "+41 79 123 45 56"
+    fill_in "event_participation_contact_data_phone_number_mobile_attributes_number",
+      with: "+41 79 123 45 56"
     fill_in "event_participation_contact_data_zip_code", with: "40202"
     fill_in "event_participation_contact_data_town", with: "Zürich"
     find(:label, "Land").click
@@ -43,8 +44,9 @@ describe "Event Signup", :js do
       expect(admin.town).to eq "Zürich"
       expect(admin.country).to eq "US"
       expect(admin.birthday).to eq Date.new(1980, 1, 1)
+      expect(admin.phone_numbers).to have(1).item
       expect(admin.phone_numbers.first.number).to eq "+41 79 123 45 56"
-      expect(admin.phone_numbers.first.label).to eq "Mobile"
+      expect(admin.phone_numbers.first.label).to eq "mobile"
     end
   end
 
@@ -95,7 +97,7 @@ describe "Event Signup", :js do
         expect(page).to have_css ".stepwizard-step.is-current", text: "Zusatzdaten"
         first(:button, "Weiter").click
         expect(page).to have_css ".stepwizard-step.is-current", text: "Subventionsbeitrag"
-        expect(page).not_to have_text "- Subvention"
+        expect(page).to have_no_text "- Subvention"
         check "Subventionierten Preis von CHF 6.00 beantragen"
         expect(page).to have_text "- Subvention"
         expect(page).to have_text "CHF 6"
@@ -105,11 +107,11 @@ describe "Event Signup", :js do
         first(:button, "Zurück").click
         expect(page).to have_css ".stepwizard-step.is-current", text: "Subventionsbeitrag"
         uncheck "Subventionierten Preis von CHF 6.00 beantragen"
-        expect(page).not_to have_text "- Subvention"
+        expect(page).to have_no_text "- Subvention"
         first(:button, "Weiter").click
         expect(page).to have_css ".stepwizard-step.is-current", text: "Zusammenfassung"
         expect(page).to have_text admin.to_s
-        expect(page).not_to have_text "- Subvention"
+        expect(page).to have_no_text "- Subvention"
         click_on "Anmelden"
         expect(page).to have_text "AGB muss akzeptiert werden"
         with_retries do

--- a/spec/features/event/sign_up_spec.rb
+++ b/spec/features/event/sign_up_spec.rb
@@ -18,7 +18,7 @@ describe "Event Signup", :js do
     fill_in "event_participation_contact_data_street", with: "Musterplatz"
     fill_in "event_participation_contact_data_housenumber", with: "42"
     fill_in "Geburtsdatum", with: "01.01.1980"
-    fill_in "event_participation_contact_data_phone_number_mobile_attributes_number",
+    fill_in "Mobil",
       with: "+41 79 123 45 56"
     fill_in "event_participation_contact_data_zip_code", with: "40202"
     fill_in "event_participation_contact_data_town", with: "Zürich"

--- a/spec/features/event_participation_spec.rb
+++ b/spec/features/event_participation_spec.rb
@@ -23,7 +23,8 @@ describe :event_participation, js: true do
     fill_in "event_participation_contact_data_street", with: "Musterplatz"
     fill_in "event_participation_contact_data_housenumber", with: "23"
     fill_in "Geburtsdatum", with: "01.01.1980"
-    fill_in "Telefon", with: "+41 79 123 45 56"
+    fill_in "event_participation_contact_data_phone_number_mobile_attributes_number",
+      with: "+41 79 123 45 56"
     fill_in "event_participation_contact_data_zip_code", with: "40202"
     fill_in "event_participation_contact_data_town", with: "Zürich"
     find(:label, "Land").click

--- a/spec/features/event_participation_spec.rb
+++ b/spec/features/event_participation_spec.rb
@@ -23,7 +23,7 @@ describe :event_participation, js: true do
     fill_in "event_participation_contact_data_street", with: "Musterplatz"
     fill_in "event_participation_contact_data_housenumber", with: "23"
     fill_in "Geburtsdatum", with: "01.01.1980"
-    fill_in "event_participation_contact_data_phone_number_mobile_attributes_number",
+    fill_in "Mobil",
       with: "+41 79 123 45 56"
     fill_in "event_participation_contact_data_zip_code", with: "40202"
     fill_in "event_participation_contact_data_town", with: "Zürich"

--- a/spec/features/groups/edit_spec.rb
+++ b/spec/features/groups/edit_spec.rb
@@ -18,8 +18,8 @@ describe "group edit page" do
       expect do
         visit edit_group_path(id: group.id)
         click_link "Kontaktangaben"
-        fill_in "group[phone_number_landline_attributes][number]", with: "0441234567"
-        fill_in "group[phone_number_mobile_attributes][number]", with: "0791234567"
+        fill_in "Festnetz", with: "0441234567"
+        fill_in "Mobil", with: "0791234567"
         click_button "Speichern"
         expect(page).to have_text(/Gruppe.*wurde erfolgreich aktualisiert./)
       end.to change { PhoneNumber.count }.by(2)
@@ -34,9 +34,9 @@ describe "group edit page" do
       expect do
         visit edit_group_path(id: group.id)
         click_link "Kontaktangaben"
-        expect(page).to have_field("group[phone_number_landline_attributes][number]",
+        expect(page).to have_field("Festnetz",
           with: "+41 44 123 45 67")
-        fill_in "group[phone_number_landline_attributes][number]", with: "+41 44 765 43 21"
+        fill_in "Festnetz", with: "+41 44 765 43 21"
         click_button "Speichern", match: :first
         expect(page).to have_text(/Gruppe.*wurde erfolgreich aktualisiert./)
       end.to change { PhoneNumber.count }.by(0)
@@ -50,12 +50,12 @@ describe "group edit page" do
       expect do
         visit edit_group_path(id: group.id)
         click_link "Kontaktangaben"
-        expect(page).to have_field("group[phone_number_landline_attributes][number]",
+        expect(page).to have_field("Festnetz",
           with: "+41 44 123 45 67")
-        expect(page).to have_field("group[phone_number_mobile_attributes][number]",
+        expect(page).to have_field("Mobil",
           with: "+41 79 123 45 67")
-        fill_in "group[phone_number_landline_attributes][number]", with: ""
-        fill_in "group[phone_number_mobile_attributes][number]", with: ""
+        fill_in "Festnetz", with: ""
+        fill_in "Mobil", with: ""
         click_button "Speichern", match: :first
         expect(page).to have_text(/Gruppe.*wurde erfolgreich aktualisiert./)
       end.to change { PhoneNumber.count }.by(-2)

--- a/spec/features/groups/edit_spec.rb
+++ b/spec/features/groups/edit_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require "spec_helper"
+
+describe "group edit page" do
+  let(:admin) { people(:admin) }
+  let(:group) { groups(:bluemlisalp_mitglieder) }
+
+  before { sign_in(admin) }
+
+  describe "phone numbers", js: true do
+    it "can set phone numbers" do
+      expect do
+        visit edit_group_path(id: group.id)
+        click_link "Kontaktangaben"
+        fill_in "group[phone_number_landline_attributes][number]", with: "0441234567"
+        fill_in "group[phone_number_mobile_attributes][number]", with: "0791234567"
+        click_button "Speichern"
+        expect(page).to have_text(/Gruppe.*wurde erfolgreich aktualisiert./)
+      end.to change { PhoneNumber.count }.by(2)
+        .and change { group.reload.phone_number_landline&.number }
+        .from(nil).to("+41 44 123 45 67")
+        .and change { group.reload.phone_number_mobile&.number }
+        .from(nil).to("+41 79 123 45 67")
+    end
+
+    it "can update phone numbers" do
+      group.create_phone_number_landline!(number: "0441234567")
+      expect do
+        visit edit_group_path(id: group.id)
+        click_link "Kontaktangaben"
+        expect(page).to have_field("group[phone_number_landline_attributes][number]",
+          with: "+41 44 123 45 67")
+        fill_in "group[phone_number_landline_attributes][number]", with: "+41 44 765 43 21"
+        click_button "Speichern", match: :first
+        expect(page).to have_text(/Gruppe.*wurde erfolgreich aktualisiert./)
+      end.to change { PhoneNumber.count }.by(0)
+        .and change { group.reload.phone_number_landline&.number }
+        .from("+41 44 123 45 67").to("+41 44 765 43 21")
+    end
+
+    it "can remove phone numbers" do
+      group.create_phone_number_landline!(number: "0441234567")
+      group.create_phone_number_mobile!(number: "0791234567")
+      expect do
+        visit edit_group_path(id: group.id)
+        click_link "Kontaktangaben"
+        expect(page).to have_field("group[phone_number_landline_attributes][number]",
+          with: "+41 44 123 45 67")
+        expect(page).to have_field("group[phone_number_mobile_attributes][number]",
+          with: "+41 79 123 45 67")
+        fill_in "group[phone_number_landline_attributes][number]", with: ""
+        fill_in "group[phone_number_mobile_attributes][number]", with: ""
+        click_button "Speichern", match: :first
+        expect(page).to have_text(/Gruppe.*wurde erfolgreich aktualisiert./)
+      end.to change { PhoneNumber.count }.by(-2)
+        .and change { group.reload.phone_number_landline&.number }
+        .from("+41 44 123 45 67").to(nil)
+        .and change { group.reload.phone_number_mobile&.number }
+        .from("+41 79 123 45 67").to(nil)
+    end
+  end
+end

--- a/spec/features/people/edit_spec.rb
+++ b/spec/features/people/edit_spec.rb
@@ -23,4 +23,52 @@ describe "person edit page" do
       expect(page).to have_text("Strasse muss ausgefüllt werden")
     end
   end
+
+  describe "phone numbers", js: true do
+    it "can set phone numbers" do
+      expect do
+        visit edit_group_person_path(group_id: member.group_ids.first, id: member.id)
+        fill_in "person[phone_number_landline_attributes][number]", with: "0441234567"
+        fill_in "person[phone_number_mobile_attributes][number]", with: "0791234567"
+        click_button "Speichern", match: :first
+        expect(page).to have_text(/Person.*wurde erfolgreich aktualisiert./)
+      end.to change { PhoneNumber.count }.by(2)
+        .and change { member.reload.phone_number_landline&.number }.from(nil).to("+41 44 123 45 67")
+        .and change { member.reload.phone_number_mobile&.number }.from(nil).to("+41 79 123 45 67")
+    end
+
+    it "can update phone numbers" do
+      member.create_phone_number_landline!(number: "0441234567")
+      expect do
+        visit edit_group_person_path(group_id: member.group_ids.first, id: member.id)
+        expect(page).to have_field("person[phone_number_landline_attributes][number]",
+          with: "+41 44 123 45 67")
+        fill_in "person[phone_number_landline_attributes][number]", with: "0447654321"
+        click_button "Speichern", match: :first
+        expect(page).to have_text(/Person.*wurde erfolgreich aktualisiert./)
+      end.to change { PhoneNumber.count }.by(0)
+        .and change { member.reload.phone_number_landline&.number }
+        .from("+41 44 123 45 67").to("+41 44 765 43 21")
+    end
+
+    it "can remove phone numbers" do
+      member.create_phone_number_landline!(number: "0441234567")
+      member.create_phone_number_mobile!(number: "0791234567")
+      expect do
+        visit edit_group_person_path(group_id: member.group_ids.first, id: member.id)
+        expect(page).to have_field("person[phone_number_landline_attributes][number]",
+          with: "+41 44 123 45 67")
+        expect(page).to have_field("person[phone_number_mobile_attributes][number]",
+          with: "+41 79 123 45 67")
+        fill_in "person[phone_number_landline_attributes][number]", with: ""
+        fill_in "person[phone_number_mobile_attributes][number]", with: ""
+        click_button "Speichern", match: :first
+        expect(page).to have_text(/Person.*wurde erfolgreich aktualisiert./)
+      end.to change { PhoneNumber.count }.by(-2)
+        .and change { member.reload.phone_number_landline&.number }
+        .from("+41 44 123 45 67").to(nil)
+        .and change { member.reload.phone_number_mobile&.number }
+        .from("+41 79 123 45 67").to(nil)
+    end
+  end
 end

--- a/spec/features/people/edit_spec.rb
+++ b/spec/features/people/edit_spec.rb
@@ -28,8 +28,8 @@ describe "person edit page" do
     it "can set phone numbers" do
       expect do
         visit edit_group_person_path(group_id: member.group_ids.first, id: member.id)
-        fill_in "person[phone_number_landline_attributes][number]", with: "0441234567"
-        fill_in "person[phone_number_mobile_attributes][number]", with: "0791234567"
+        fill_in "Festnetz", with: "0441234567"
+        fill_in "Mobil", with: "0791234567"
         click_button "Speichern", match: :first
         expect(page).to have_text(/Person.*wurde erfolgreich aktualisiert./)
       end.to change { PhoneNumber.count }.by(2)
@@ -41,9 +41,9 @@ describe "person edit page" do
       member.create_phone_number_landline!(number: "0441234567")
       expect do
         visit edit_group_person_path(group_id: member.group_ids.first, id: member.id)
-        expect(page).to have_field("person[phone_number_landline_attributes][number]",
+        expect(page).to have_field("Festnetz",
           with: "+41 44 123 45 67")
-        fill_in "person[phone_number_landline_attributes][number]", with: "0447654321"
+        fill_in "Festnetz", with: "0447654321"
         click_button "Speichern", match: :first
         expect(page).to have_text(/Person.*wurde erfolgreich aktualisiert./)
       end.to change { PhoneNumber.count }.by(0)
@@ -56,12 +56,12 @@ describe "person edit page" do
       member.create_phone_number_mobile!(number: "0791234567")
       expect do
         visit edit_group_person_path(group_id: member.group_ids.first, id: member.id)
-        expect(page).to have_field("person[phone_number_landline_attributes][number]",
+        expect(page).to have_field("Festnetz",
           with: "+41 44 123 45 67")
-        expect(page).to have_field("person[phone_number_mobile_attributes][number]",
+        expect(page).to have_field("Mobil",
           with: "+41 79 123 45 67")
-        fill_in "person[phone_number_landline_attributes][number]", with: ""
-        fill_in "person[phone_number_mobile_attributes][number]", with: ""
+        fill_in "Festnetz", with: ""
+        fill_in "Mobil", with: ""
         click_button "Speichern", match: :first
         expect(page).to have_text(/Person.*wurde erfolgreich aktualisiert./)
       end.to change { PhoneNumber.count }.by(-2)

--- a/spec/jobs/sac_cas/export/mitglieder_export_job_spec.rb
+++ b/spec/jobs/sac_cas/export/mitglieder_export_job_spec.rb
@@ -68,7 +68,7 @@ describe SacCas::Export::MitgliederExportJob do
   # This export generates a legacy file format which MUST NOT prefix phone numbers.
   it "does not prefix phone numbers with single quote" do
     person = people(:mitglied)
-    person.phone_numbers.create!(number: "+41 79 123 45 67", label: "Haupt-Telefon")
+    person.create_phone_number_mobile!(number: "+41 79 123 45 67")
     job.perform
     expect(contents).to include "$+41 79 123 45 67$"
   end

--- a/spec/models/event/participation_contact_data_spec.rb
+++ b/spec/models/event/participation_contact_data_spec.rb
@@ -9,53 +9,73 @@ require "spec_helper"
 
 describe Event::ParticipationContactData do
   let(:event) { Fabricate.build(:course) }
-  let(:person) { Fabricate.build(:person) }
+  let(:person) { Fabricate.create(:person) }
+
+  let(:attrs) {
+    {
+      first_name: "Max",
+      last_name: "Muster",
+      street: "Musterplatz",
+      housenumber: "23",
+      email: "max.muster@example.com",
+      zip_code: "8000",
+      town: "Zürich",
+      country: "CH",
+      birthday: "01.01.1980",
+      phone_number_mobile_attributes: {
+        number: "+41 79 123 45 56"
+      }
+    }.with_indifferent_access
+  }
 
   describe "::validations" do
-    let(:attrs) {
-      {
-        first_name: "Max",
-        last_name: "Muster",
-        street: "Musterplatz",
-        housenumber: "23",
-        email: "max.muster@example.com",
-        zip_code: "8000",
-        town: "Zürich",
-        country: "CH",
-        birthday: "01.01.1980",
-        phone_numbers_attributes: {
-          "0": {
-            number: "+41 79 123 45 56",
-            public: true,
-            translated_label: "Mobile"
-          }
-        }
-      }.with_indifferent_access
-    }
-
     it "is valid if required attributes are set" do
       expect(build(attrs)).to be_valid
     end
 
-    it "is invalid if phone number is blank" do
-      attrs[:phone_numbers_attributes]["0"]["number"] = ""
+    it "is invalid if all numbers are blank" do
+      attrs[:phone_number_mobile_attributes]["number"] = ""
       contact_data = build(attrs)
       expect(contact_data).not_to be_valid
       expect(contact_data.errors.full_messages).to eq [
-        "Telefon muss ausgefüllt werden"
+        "Telefonnummer muss ausgefüllt werden"
       ]
-      expect(contact_data.person.phone_numbers.first).to have(2).errors_on(:number)
     end
 
     it "is invalid if phone number is invalid" do
-      attrs[:phone_numbers_attributes]["0"]["number"] = "test"
+      attrs[:phone_number_mobile_attributes]["number"] = "test"
       contact_data = build(attrs)
       expect(contact_data).not_to be_valid
       expect(contact_data.errors.full_messages).to eq [
-        "Telefonnummer ist nicht gültig"
+        "Mobiltelefon ist nicht gültig"
       ]
-      expect(contact_data.person.phone_numbers.first).to have(1).error_on(:number)
+      expect(contact_data.person.phone_number_mobile).to have(1).error_on(:number)
     end
+  end
+
+  it "can handle deletion and mutation of phone-number" do
+    attrs.delete(:phone_number_mobile_attributes)
+    existing_number = person.create_phone_number_landline(number: "044 112 00 00")
+    expect(person.phone_numbers.count).to eq 1
+
+    contact_data = build(attrs.merge(
+      # remove the single existing number
+      phone_number_landline_attributes: {id: existing_number.id, number: ""}
+    ))
+    expect(contact_data).not_to be_valid
+
+    contact_data = build(attrs.merge(
+      # remove the existing number, add another one
+      phone_number_landline_attributes: {id: existing_number.id, number: ""},
+      phone_number_mobile_attributes: {id: nil, number: "079 123 45 67"}
+    ))
+    expect(contact_data).to be_valid
+
+    contact_data = build(attrs.merge(
+      # add another number besides the existing one
+      phone_number_mobile_attributes: {id: nil, number: "079 123 45 67"}
+    ))
+    expect(contact_data).to be_valid
   end
 
   def build(attributes)

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -8,7 +8,17 @@
 require "spec_helper"
 
 describe Person do
-  context "family_id" do
+  context "associations" do
+    %w[landline mobile].each do |label|
+      it "#phone_number_#{label} returns the number with label #{label.inspect}" do
+        person = people(:mitglied)
+        phone_number = person.phone_numbers.create!(number: "+41791234567", label: label)
+        expect(person.send(:"phone_number_#{label}")).to eq(phone_number)
+      end
+    end
+  end
+
+  context "#family_id" do
     let(:group) { groups(:bluemlisalp_mitglieder) }
     let(:person) { Fabricate(:person, household_key: "1234ABCD", birthday: 25.years.ago) }
 

--- a/spec/models/phone_number_spec.rb
+++ b/spec/models/phone_number_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+require "spec_helper"
+
+describe PhoneNumber do
+  it "::predefined_labels" do
+    expect(PhoneNumber.predefined_labels).to eq(%w[landline mobile])
+  end
+
+  context "validations" do
+    let(:contactable) { people(:mitglied) }
+    let(:phone_number) { PhoneNumber.new(contactable:, number: "0780000000") }
+
+    describe "label" do
+      it "accepts predefined labels" do
+        PhoneNumber.predefined_labels.each do |label|
+          phone_number.label = label
+          expect(phone_number).to be_valid
+        end
+      end
+
+      it "rejects other labels" do
+        phone_number.label = "invalid_label"
+        expect(phone_number).not_to be_valid
+        expect(phone_number.errors[:label]).to include("ist kein gültiger Wert")
+      end
+
+      it "validates presence of label" do
+        expect(phone_number).not_to be_valid
+        expect(phone_number.errors[:label]).to include("ist kein gültiger Wert")
+      end
+
+      it "validates uniqueness of label scoped to contactable_type and contactable_id" do
+        _existing_phone_number = PhoneNumber.create!(
+          contactable: people(:mitglied),
+          label: "landline",
+          number: "0780000000"
+        )
+
+        phone_number.label = "landline"
+        expect(phone_number).not_to be_valid
+        expect(phone_number.errors[:label]).to include("ist bereits vergeben")
+
+        phone_number.label = "mobile"
+        expect(phone_number).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/wizards/signup/sektion_operation_spec.rb
+++ b/spec/models/wizards/signup/sektion_operation_spec.rb
@@ -25,9 +25,7 @@ describe Wizards::Signup::SektionOperation do
       zip_code: "8000",
       birthday: "1.1.2000",
       country: "CH",
-      phone_numbers_attributes: [
-        {number: "0791234567", label: "Mobil"}
-      ]
+      phone_number_mobile_attributes: {number: "0791234567"}
     }
   }
 
@@ -80,7 +78,8 @@ describe Wizards::Signup::SektionOperation do
 
       expect(max.roles.first.type).to eq "Group::SektionsNeuanmeldungenSektion::Neuanmeldung"
       expect(max.roles.first.group).to eq group
-      expect(max.phone_numbers.first.label).to eq "Mobil"
+      expect(max.phone_numbers).to have(1).item
+      expect(max.phone_numbers.first.label).to eq "mobile"
       expect(max.phone_numbers.first.number).to eq "+41 79 123 45 67"
     end
 
@@ -201,7 +200,7 @@ describe Wizards::Signup::SektionOperation do
 
         expect(person.roles.last.type).to eq "Group::SektionsNeuanmeldungenSektion::Neuanmeldung"
         expect(person.roles.last.group).to eq group
-        expect(person.phone_numbers.first.label).to eq "Mobil"
+        expect(person.phone_numbers.first.label).to eq "mobile"
         expect(person.phone_numbers.first.number).to eq "+41 79 123 45 67"
         expect(mailing_lists(:newsletter).people).to eq [person]
       end
@@ -212,8 +211,8 @@ describe Wizards::Signup::SektionOperation do
       end
 
       it "does not duplicate phone_number when id is set" do
-        number = person.phone_numbers.create!(label: "Mobil", number: "+41 79 123 45 67")
-        person_attrs[:phone_numbers_attributes][0][:id] = number.id
+        number = person.phone_numbers.create!(label: "mobile", number: "+41 79 123 45 67")
+        person_attrs[:phone_number_mobile_attributes][:id] = number.id
 
         expect { operation.save! }
           .to change { person.roles.count }

--- a/spec/models/wizards/steps/signup/person_fields_spec.rb
+++ b/spec/models/wizards/steps/signup/person_fields_spec.rb
@@ -114,9 +114,9 @@ describe Wizards::Steps::Signup::PersonFields do
     end
 
     it "reads phone_number if present" do
-      number = person.phone_numbers.create!(label: "Mobil", number: "0791234567")
+      number = person.phone_numbers.create!(label: "mobile", number: "0791234567")
       expect(form.phone_number).to eq "+41 79 123 45 67"
-      expect(form.person_attributes[:phone_numbers_attributes][0][:id]).to eq number.id
+      expect(form.person_attributes[:phone_number_mobile_attributes][:id]).to eq number.id
     end
 
     it "params override values read from person" do

--- a/spec/models/wizards/steps/signup/sektion/family_fields/member_spec.rb
+++ b/spec/models/wizards/steps/signup/sektion/family_fields/member_spec.rb
@@ -102,7 +102,7 @@ describe Wizards::Steps::Signup::Sektion::FamilyFields::Member do
       .except(:phone_number)
       .merge(
         birthday: Date.new(2000, 1, 1),
-        phone_numbers_attributes: [{label: "Mobil", number: "0791234567"}]
+        phone_number_mobile_attributes: {id: nil, number: "0791234567"}
       )
   end
 end

--- a/spec/models/wizards/steps/signup/sektion/family_fields_spec.rb
+++ b/spec/models/wizards/steps/signup/sektion/family_fields_spec.rb
@@ -31,7 +31,7 @@ describe Wizards::Steps::Signup::Sektion::FamilyFields do
     expect(form.members[0].person_attributes).to eq(required_attrs
       .merge(birthday: Date.new(2000, 1, 1))
       .except(:phone_number)
-      .merge(phone_numbers_attributes: [{label: "Mobil", number: "0791234567"}]))
+      .merge(phone_number_mobile_attributes: {id: nil, number: "0791234567"}))
   end
 
   describe "validations" do

--- a/spec/models/wizards/steps/signup/sektion/person_fields_spec.rb
+++ b/spec/models/wizards/steps/signup/sektion/person_fields_spec.rb
@@ -81,7 +81,7 @@ describe Wizards::Steps::Signup::Sektion::PersonFields do
       .merge(
         country: "CH",
         birthday: Date.new(2000, 1, 1),
-        phone_numbers_attributes: [{label: "Mobil", number: "0791234567"}]
+        phone_number_mobile_attributes: {id: nil, number: "0791234567"}
       )
   end
 end

--- a/spec/requests/oauth_profile_spec.rb
+++ b/spec/requests/oauth_profile_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe "GET oauth/profile", type: :request do
         country: user.country,
         picture_url: %r{packs(-test)?/media/images/profile-.*\.svg},
         membership_verify_url: "http://localhost:3000/verify_membership/aSuperSweetToken42",
-        phone: nil
+        phone_number_landline: nil,
+        phone_number_mobile: nil
       }.deep_stringify_keys)
     end
   end
@@ -81,7 +82,8 @@ RSpec.describe "GET oauth/profile", type: :request do
         language: user.language,
         picture_url: "http://www.example.com/packs-test/media/images/profile-c150952c7e2ec2cf298980d55b2bcde3.svg",
         membership_verify_url: "http://localhost:3000/verify_membership/aSuperSweetToken42",
-        phone: nil,
+        phone_number_landline: nil,
+        phone_number_mobile: nil,
         membership_years: user.membership_years,
         roles: [{
           group_id: user.roles.first.group_id,

--- a/spec/support/graphiti/schema.json
+++ b/spec/support/graphiti/schema.json
@@ -1708,6 +1708,26 @@
           "readable": true,
           "description": null
         },
+        "foundation_year": {
+          "type": "string",
+          "readable": true,
+          "description": null
+        },
+        "section_canton": {
+          "type": "string",
+          "readable": true,
+          "description": null
+        },
+        "language": {
+          "type": "string",
+          "readable": true,
+          "description": null
+        },
+        "mitglied_termination_by_section_only": {
+          "type": "string",
+          "readable": true,
+          "description": null
+        },
         "course_admin_email": {
           "type": "string",
           "readable": true,
@@ -1749,26 +1769,6 @@
           "description": null
         },
         "abo_alpen_postage_abroad_article_number": {
-          "type": "string",
-          "readable": true,
-          "description": null
-        },
-        "foundation_year": {
-          "type": "string",
-          "readable": true,
-          "description": null
-        },
-        "section_canton": {
-          "type": "string",
-          "readable": true,
-          "description": null
-        },
-        "language": {
-          "type": "string",
-          "readable": true,
-          "description": null
-        },
-        "mitglied_termination_by_section_only": {
           "type": "string",
           "readable": true,
           "description": null


### PR DESCRIPTION
* in SAC wagon, Person and Group can have only two phone numbers with distinct labels
* valid labels are "mobile" and "landline"
* form fields are fixed, not dynamic as in core
* public flag is not editable
* OIDC claim contains both numbers
* Sign-up wizards fill the phone_number with label "mobile"

fixes #1563
