### PR TITLE
Favour string over constants if code is loaded initialization

### DIFF
--- a/app/jobs/export/backup_mitglieder_schedule_job.rb
+++ b/app/jobs/export/backup_mitglieder_schedule_job.rb
@@ -8,7 +8,7 @@
 class Export::BackupMitgliederScheduleJob < RecurringJob
   run_every 1.day
 
-  ROLE_TYPES_TO_BACKUP = [Group::Sektion, Group::Ortsgruppe].map(&:sti_name)
+  ROLE_TYPES_TO_BACKUP = %w[Group::Sektion Group::Ortsgruppe]
 
   def perform_internal
     relevant_groups.find_each do |group|


### PR DESCRIPTION
As we reference this class in the wagon file and it is referenced
before the model mixins are inserted, this results on misconfigured
Sektion and Ortsgruppe models
