### PR TITLE
Consolidate links on login pages (#1908)

### DIFF
--- a/app/views/devise/sessions/_helpful_links.html.haml
+++ b/app/views/devise/sessions/_helpful_links.html.haml
@@ -1,0 +1,14 @@
+- #  copyright (c) 2024, schweizer alpen-club. this file is part of
+- #  hitobito_sac_cas and licensed under the affero general public license version 3
+- #  or later. see the copying file at the top-level directory or at
+- #  https://github.com/hitobito/hitobito_sac_cas.
+%div.m-0
+  = link_to t('layouts.unauthorized.forgot_password'), new_person_password_path
+  %span.hide-last
+    |
+  = link_to t('layouts.unauthorized.need_confirmation_email'), new_person_confirmation_path
+%div.m-0
+  = render_self_registration_link
+  %span.hide-last
+    |
+  = link_to t('public_events.show.request_sac_membership'), t("public_events.show.request_sac_membership_link")

--- a/app/views/public_events/show.html.haml
+++ b/app/views/public_events/show.html.haml
@@ -9,14 +9,3 @@
     %h2=t(".with_sac_account")
 
   = render 'devise/sessions/form', autofocus_login: false
-  .align-with-form.mt-4
-    .mb-1=t(".is_sac_account_active")
-    = link_to t('.login_questions'), t(".link_fag_sac_account")
-
-    %h2.mt-5=t(".first_time_here")
-    .mb-2=t(".create_account_now")
-  = render 'event/register/email_check'
-
-  .align-with-form.mt-5
-    %h2=t(".wanna_be_a_member")
-    = link_to t('.request_sac_membership'), t(".request_sac_membership_link")

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -27,6 +27,10 @@ de:
       website: "https://www.sac-cas.ch"
     title_event/tour: Tour
 
+  layouts:
+    unauthorized:
+      main_self_registration: Kein SAC-Mitglied? Kostenloses SAC-Konto eröffnen
+
   settings:
     email:
       sender: Schweizer Alpen-Club SAC <noreply@%{mail_domain}>
@@ -1832,12 +1836,6 @@ de:
     show:
       login_to_participate: Melde dich an, um an diesem Kurs teilzunehmen
       with_sac_account: mit deinem SAC-Konto
-      is_sac_account_active: "Für SAC-Mitglieder: Ist dein persönliches SAC-Konto noch nicht aktiviert?"
-      login_questions: Fragen und Antworten zum Login
-      link_fag_sac_account: https://www.sac-cas.ch/de/meta/faq/faq-sac-konto/
-      first_time_here: Zum ersten Mal hier?
-      create_account_now: Jetzt dein kostenloses SAC-Konto erstellen
-      wanna_be_a_member: Möchtest du SAC-Mitglied werden?
       request_sac_membership: SAC Mitgliedschaft beantragen
       request_sac_membership_link: https://www.sac-cas.ch/de/mitgliedschaft/mitglied-werden/
 

--- a/db/migrate/20250709160605_set_main_self_registration_group.rb
+++ b/db/migrate/20250709160605_set_main_self_registration_group.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2024, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class SetMainSelfRegistrationGroup < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE groups SET main_self_registration_group = true WHERE id IN
+            (SELECT id FROM groups WHERE type = 'Group::AboBasicLogin' LIMIT 1);
+        SQL
+      end
+      dir.down do
+        execute "UPDATE groups SET main_self_registration_group = false WHERE type = 'Group::AboBasicLogin'"
+      end
+    end
+  end
+end

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -52,7 +52,7 @@ abo_basic_login:
   type: Group::AboBasicLogin
   layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
   self_registration_role_type: "Group::AboBasicLogin::BasicLogin"
-  created_at: 2023-05-09 13:28:00 # set manually because Group::Types#create_default_children HACK
+  main_self_registration_group: true
 
 externe_kontakte:
   parent: root

--- a/spec/views/devise/sessions/new.html.haml_spec.rb
+++ b/spec/views/devise/sessions/new.html.haml_spec.rb
@@ -1,0 +1,38 @@
+#  Copyright (c) 2012-2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe "devise/sessions/new.html.haml" do
+  subject(:dom) { Capybara::Node::Simple.new(raw(rendered)) }
+
+  let(:group) { groups(:abo_basic_login) }
+
+  before do
+    group.update!(main_self_registration_group: true)
+    allow(view).to receive(:resource).and_return(Person.new)
+  end
+
+  it "does render custom helpful links" do
+    render
+    expect(dom).to have_link "Passwort vergessen", href: new_person_password_path
+    expect(dom).to have_link "Keine Bestätigungs-E-Mail bekommen?", href: new_person_confirmation_path
+    expect(dom).to have_link "Kein SAC-Mitglied? Kostenloses SAC-Konto eröffnen", href: group_self_registration_path(group)
+    expect(dom).to have_link "SAC Mitgliedschaft beantragen", href: "https://www.sac-cas.ch/de/mitgliedschaft/mitglied-werden/"
+  end
+
+  describe "oauth" do
+    before { params[:oauth] = "true" }
+
+    it "does render custom helpful links" do
+      render
+      expect(dom).to have_text "Bitte melde dich an, um weiter zu gelangen."
+      expect(dom).to have_link "Passwort vergessen", href: new_person_password_path
+      expect(dom).to have_link "Keine Bestätigungs-E-Mail bekommen?", href: new_person_confirmation_path
+      expect(dom).to have_link "Kein SAC-Mitglied? Kostenloses SAC-Konto eröffnen", href: group_self_registration_path(group)
+      expect(dom).to have_link "SAC Mitgliedschaft beantragen", href: "https://www.sac-cas.ch/de/mitgliedschaft/mitglied-werden/"
+    end
+  end
+end

--- a/spec/views/devise/sessions/new.html.haml_spec.rb
+++ b/spec/views/devise/sessions/new.html.haml_spec.rb
@@ -1,4 +1,4 @@
-#  Copyright (c) 2012-2023, Schweizer Alpen-Club. This file is part of
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
 #  hitobito_sac_cas and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sac_cas.
@@ -11,7 +11,6 @@ describe "devise/sessions/new.html.haml" do
   let(:group) { groups(:abo_basic_login) }
 
   before do
-    group.update!(main_self_registration_group: true)
     allow(view).to receive(:resource).and_return(Person.new)
   end
 

--- a/spec/views/public_events/show.html.haml_spec.rb
+++ b/spec/views/public_events/show.html.haml_spec.rb
@@ -12,7 +12,6 @@ describe "public_events/show.html.haml" do
   subject(:dom) { Capybara::Node::Simple.new(raw(rendered)) }
 
   before do
-    group.update!(main_self_registration_group: true)
     allow(view).to receive(:resource).and_return(Person.new)
   end
 

--- a/spec/views/public_events/show.html.haml_spec.rb
+++ b/spec/views/public_events/show.html.haml_spec.rb
@@ -1,0 +1,26 @@
+#  Copyright (c) 2012-2023, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe "public_events/show.html.haml" do
+  let(:group) { groups(:abo_basic_login) }
+  let(:event) { EventDecorator.decorate(events(:top_course)) }
+
+  subject(:dom) { Capybara::Node::Simple.new(raw(rendered)) }
+
+  before do
+    group.update!(main_self_registration_group: true)
+    allow(view).to receive(:resource).and_return(Person.new)
+  end
+
+  it "does render custom helpful links" do
+    render
+    expect(dom).to have_link "Passwort vergessen", href: new_person_password_path
+    expect(dom).to have_link "Keine Bestätigungs-E-Mail bekommen?", href: new_person_confirmation_path
+    expect(dom).to have_link "Kein SAC-Mitglied? Kostenloses SAC-Konto eröffnen", href: group_self_registration_path(group)
+    expect(dom).to have_link "SAC Mitgliedschaft beantragen", href: "https://www.sac-cas.ch/de/mitgliedschaft/mitglied-werden/"
+  end
+end


### PR DESCRIPTION
Specs sind eigentlich in ordnung, sieht aber so aus als ob das automatische Branch wechseln weg vom  `sac-master` nicht funktioniert https://github.com/hitobito/hitobito_sac_cas/actions/runs/16219245706/job/45795578338?pr=1914#step:3:66