### PR TITLE
Fix 500 on participations list with invoice_status column

### DIFF
--- a/app/domain/table_displays/people/sektion_member_admin_visible.rb
+++ b/app/domain/table_displays/people/sektion_member_admin_visible.rb
@@ -17,7 +17,7 @@ module TableDisplays::People
 
     # this required_model_includes could be removed if we relied solely on our abilities
     def required_model_includes(_attr)
-      super + ((@model_class == Person) ? [roles_unscoped: :group] : [person: {roles_unscoped: :group}])
+      super + ((@model_class == Person) ? [roles_unscoped: :group] : [])
     end
 
     private


### PR DESCRIPTION
Due to the polymorphism introduced for the [event guests feature](https://github.com/hitobito/hitobito_sww/issues/208), including person (or participant) is not possible anymore. We should use the Event::Participation::PreloadParticipations class for this, but this is nontrivial to do in this case.
For now, an n+1 is better than a 500.

Quick fixes https://sentry.puzzle.ch/pitc/hitobito-backend/issues/79144