### PR TITLE
Fix Wizards::Steps::ChooseSektion#self_service?, fixes #2040

### DIFF
--- a/app/decorators/sac_cas/group_decorator.rb
+++ b/app/decorators/sac_cas/group_decorator.rb
@@ -18,10 +18,12 @@ module SacCas::GroupDecorator
   def membership_admission_through_gs?
     return unless sektion_or_ortsgruppe?
 
-    object.children.without_deleted.none? { |group|
-      group.is_a?(Group::SektionsNeuanmeldungenSektion)
-    }
+    object
+      .children.without_deleted
+      .none? { |group| group.is_a?(Group::SektionsNeuanmeldungenSektion) }
   end
+  alias_method :membership_admission_self_service?,
+    :membership_admission_through_gs?
 
   def membership_self_registration_url
     return unless sektion_or_ortsgruppe?

--- a/app/models/wizards/steps/choose_sektion.rb
+++ b/app/models/wizards/steps/choose_sektion.rb
@@ -26,8 +26,7 @@ module Wizards
       end
 
       def self_service?
-        @self_service ||= Group::SektionsNeuanmeldungenSektion
-          .where(layer_group_id: group&.id).none?
+        @self_service ||= group&.decorate&.membership_admission_self_service?
       end
 
       private

--- a/spec/decorators/group_decorator_spec.rb
+++ b/spec/decorators/group_decorator_spec.rb
@@ -196,14 +196,21 @@ describe GroupDecorator do
 
       it "returns true without child SektionsNeuanmeldungenSektion" do
         group.children.where(type: Group::SektionsNeuanmeldungenSektion.sti_name).delete_all
+        expect(Group::SektionsNeuanmeldungenSektion.with_deleted.where(parent: group)).to be_empty
+
+        expect(decorator.membership_admission_through_gs?).to eq true
+      end
+
+      it "returns true with destroyed child SektionsNeuanmeldungenSektion" do
+        group.children.where(type: Group::SektionsNeuanmeldungenSektion.sti_name).destroy_all
+        expect(Group::SektionsNeuanmeldungenSektion.deleted.where(parent: group)).to be_exists
 
         expect(decorator.membership_admission_through_gs?).to eq true
       end
 
       it "returns false with child SektionsNeuanmeldungenSektion" do
-        # rubocop:todo Layout/LineLength
-        expect(group.children.where(type: Group::SektionsNeuanmeldungenSektion.sti_name)).to be_exists
-        # rubocop:enable Layout/LineLength
+        expect(group.children.where(type: Group::SektionsNeuanmeldungenSektion.sti_name))
+          .to be_exists
 
         expect(decorator.membership_admission_through_gs?).to eq false
       end
@@ -213,9 +220,7 @@ describe GroupDecorator do
       let(:group) { groups(:bluemlisalp_ortsgruppe_ausserberg) }
 
       it "returns true without child SektionsNeuanmeldungenSektion" do
-        # rubocop:todo Layout/LineLength
-        expect(group.children.where(type: Group::SektionsNeuanmeldungenSektion.sti_name)).not_to be_exists
-        # rubocop:enable Layout/LineLength
+        expect(Group::SektionsNeuanmeldungenSektion.with_deleted.where(parent: group)).to be_empty
 
         expect(decorator.membership_admission_through_gs?).to eq true
       end
@@ -224,9 +229,8 @@ describe GroupDecorator do
         Fabricate(Group::SektionsNeuanmeldungenSektion.sti_name,
           parent: groups(:bluemlisalp_ortsgruppe_ausserberg))
 
-        # rubocop:todo Layout/LineLength
-        expect(group.children.where(type: Group::SektionsNeuanmeldungenSektion.sti_name)).to be_exists
-        # rubocop:enable Layout/LineLength
+        expect(group.children.where(type: Group::SektionsNeuanmeldungenSektion.sti_name))
+          .to be_exists
 
         expect(decorator.membership_admission_through_gs?).to eq false
       end

--- a/spec/models/wizards/steps/choose_sektion_spec.rb
+++ b/spec/models/wizards/steps/choose_sektion_spec.rb
@@ -65,11 +65,13 @@ describe Wizards::Steps::ChooseSektion do
 
       it "is invalid when triggered by normal user" do
         allow(wizard).to receive(:backoffice?).and_return(false)
-        expect(step).not_to be_valid
-        expect(step.errors[:base]).to eq [
-          "Wir bitten dich den gewünschten Sektionswechsel telefonisch oder per " \
-          "E-Mail* zu beantragen. Nimm dazu bitte Kontakt mit uns auf."
-        ]
+        aggregate_failures do
+          expect(step).to be_invalid
+          expect(step.errors[:base]).to eq [
+            "Wir bitten dich den gewünschten Sektionswechsel telefonisch oder per " \
+            "E-Mail* zu beantragen. Nimm dazu bitte Kontakt mit uns auf."
+          ]
+        end
       end
 
       it "is valid when triggered by backoffice user" do
@@ -79,7 +81,7 @@ describe Wizards::Steps::ChooseSektion do
 
       it "is valid when triggered by normal user but self service is allowed" do
         Group::SektionsNeuanmeldungenSektion.destroy_all
-        expect(step).not_to be_valid
+        expect(step).to be_valid
       end
     end
   end


### PR DESCRIPTION
The original implementation did not filter deleted groups, so the return
value was wrong if a deleted group existed.
The new implementation uses the existing and correctly working method
on the Group decorator instead of re-implementing the logic.
