### PR TITLE
Fix event participation table displays

### DIFF
--- a/app/domain/table_displays/people/sektion_member_admin_visible.rb
+++ b/app/domain/table_displays/people/sektion_member_admin_visible.rb
@@ -17,19 +17,21 @@ module TableDisplays::People
 
     # this required_model_includes could be removed if we relied solely on our abilities
     def required_model_includes(_attr)
-      # rubocop:todo Layout/LineLength
-      super + ((@model_class == Person) ? [roles_unscoped: :group] : [])
-      # rubocop:enable Layout/LineLength
+      super + unscoped_person_roles_includes
     end
 
     private
+
+    def unscoped_person_roles_includes
+      (@model_class == Person) ? [roles_unscoped: :group] : [participant: [roles_unscoped: :group]]
+    end
 
     def allowed?(object, attr, _original_object, _original_attr)
       super || (section_admin_layer_ids & object_membership_layer_ids(object)).any?
     end
 
     def object_membership_layer_ids(object)
-      roles_unscoped(object).select do |role|
+      roles_unscoped(object).to_a.select do |role|
         SacCas::MITGLIED_ROLES.include?(role.class)
       end.map { |role| role.group.layer_group_id }
     end
@@ -43,8 +45,7 @@ module TableDisplays::People
     def roles_unscoped(object)
       case object
       when Person then object.roles_unscoped
-      when Event::Participation then object.participant.roles_unscoped
-      else []
+      when Event::Participation then object.participant.try(:roles_unscoped)
       end
     end
   end

--- a/spec/domain/table_displays/people/sektion_member_admin_visible_spec.rb
+++ b/spec/domain/table_displays/people/sektion_member_admin_visible_spec.rb
@@ -22,9 +22,10 @@ describe TableDisplays::People::SektionMemberAdminVisible, type: :helper do
     roles(:mitglied).update!(end_on: Date.new(2025, 3, 10))
   end
 
-  [[Person, [:roles_with_ended_readable, {roles_unscoped: :group}]],
-    [Event::Participation,
-      [:roles_with_ended_readable]]].each do |model_class, expected_includes|
+  [
+    [Person, [:roles_with_ended_readable, {roles_unscoped: :group}]],
+    [Event::Participation, [:roles_with_ended_readable, participant: [{roles_unscoped: :group}]]]
+  ].each do |model_class, expected_includes|
     context "table display on #{model_class}" do
       subject(:column) {
         TableDisplays::People::TerminateOnColumn.new(ability, model_class: model_class)


### PR DESCRIPTION
Fixes #2089

Since hitobito/hitobito#3250, inactive roles are taken into account for giving SektionMemberAdmins access to the table display columns of people.

In #1868, this was extended to not crash for event participations.

Since hitobito/hitobito_sww#208, event_participations are polymorphic and normal includes cannot be used for preloading the person anymore.

The quick fix is to abandon preloading the unscoped roles for event_participations for now. It is not entirely clear to me whether this past-role-based access was supposed to work for event participations as well. If it was, this may need a different, more extensive fix.