### PR TITLE
Restore person abilities to original behaviour

### DIFF
--- a/app/abilities/sac_cas/person_ability.rb
+++ b/app/abilities/sac_cas/person_ability.rb
@@ -29,6 +29,12 @@ module SacCas::PersonAbility
       permission(:any).may(:manage_national_office_remark).if_backoffice
       permission(:any).may(:manage_section_remarks).if_backoffice_or_functionary
       permission(:any).may(:log).if_backoffice_or_backoffice_readonly
+
+      for_self_or_manageds do
+        # In the core, the following permissions are not allowed for basic_permissions_roles.
+        # The SAC wagon relaxes these. See https://github.com/hitobito/hitobito/pull/3757#discussion_r2541422585
+        permission(:any).may(:show_details, :show_full, :history).herself
+      end
     end
   end
 


### PR DESCRIPTION
Some permission relaxation of the youth wagon got lost when moving the Elternzugang to the core. Since only the SAC wagon is using them explicitly, we decided to restore them in the wagon.

More details can be found here: https://github.com/hitobito/hitobito/pull/3757#discussion_r2541422585