### PR TITLE
Create missing people managers on UndoTermination#save

### DIFF
--- a/app/models/memberships/undo_termination.rb
+++ b/app/models/memberships/undo_termination.rb
@@ -101,6 +101,7 @@ module Memberships
         restored_people.each { _1.save(validate: false) if _1.changed? }
         restored_roles.each { _1.save(validate: false) }
         roles_to_destroy.each(&:destroy)
+        role.person.reload.household.create_missing_people_managers
       end
       true
     end

--- a/app/models/sac_cas/household.rb
+++ b/app/models/sac_cas/household.rb
@@ -68,11 +68,12 @@ module SacCas::Household
     @maintain_sac_family
   end
 
-  def create_missing_people_managers(manager)
+  def create_missing_people_managers(manager = main_person)
     return if manager.nil?
 
     change_manageds = people - [manager] - manager.manageds
     clear_people_managers(change_manageds)
+
     change_manageds.each do |managed|
       PeopleManager.create!(manager:, managed:)
     end

--- a/spec/models/memberships/undo_termination_spec.rb
+++ b/spec/models/memberships/undo_termination_spec.rb
@@ -512,6 +512,16 @@ describe Memberships::UndoTermination, versioning: true do
         expect(role.person.household_key).to eq original_household_key
         expect(role.person.household.people).to match_array original_household_people
       end
+
+      it "creates missing people managers" do
+        expect(role.person.manageds).to be_present
+        terminate(role)
+        expect(role.person.manageds).to be_empty
+
+        subject.save!
+
+        expect(role.reload.person.manageds).to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
`UndoTermination#save` should restore the family/household as it was
before terminating the membership. This change ensures that the people
managers get recreated, this was missing before.

Pragmatically we don't try to restore the people managers as they were
before the termiation, but we let `Household#create_missing_people_managers`
create new ones as valid for the current context/time.
