### PR TITLE
Make mailing list subscribable for labels customizable (#2013)

### DIFF
--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -513,6 +513,13 @@ de:
         number: Mobiltelefon
       group/phone_number_landline:
         number: Festnetztelefon
+
+      mailing_list:
+        subscribable_fors:
+          anyone: Alle Personen des Schweizer Alpen-Clubs (u. A. alle Sektionen)
+          configured: Nur konfigurierte Abonnenten (z.B. Sektionsmitglieder)
+          nobody: Niemand
+
       role:
         membership_years: Mitglieder-Jahre
         class:

--- a/spec/models/mailing_list_spec.rb
+++ b/spec/models/mailing_list_spec.rb
@@ -42,6 +42,15 @@ describe MailingList do
       expect(newsletter.filter_chain.to_hash).to be_blank
     end
 
+    it "has customized subscribable_for translations" do
+      label_nobody = subject.subscribable_for_label(:nobody)
+      label_anyone = subject.subscribable_for_label(:anyone)
+      label_configured = subject.subscribable_for_label(:configured)
+      expect(label_nobody).to eq "Niemand"
+      expect(label_anyone).to eq "Alle Personen des Schweizer Alpen-Clubs (u. A. alle Sektionen)"
+      expect(label_configured).to eq "Nur konfigurierte Abonnenten (z.B. Sektionsmitglieder)"
+    end
+
     it "newsletter mailing list subscription is empty" do
       MailingListSeeder.seed!
       expect(newsletter.subscriptions).to be_empty


### PR DESCRIPTION
:warning: Nach dem Integrations deployment müssen die keys für FR und IT noch im Transifex ergänzt werden.