### PR TITLE
Simple script to migrate mailing lists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,4 +10,3 @@ AllCops:
     - config/**/*
     - bin/**/*
     - tmp/**/*
-    - lib/tty/**/*

--- a/app/domain/migrate_list.rb
+++ b/app/domain/migrate_list.rb
@@ -1,0 +1,103 @@
+module MigrateList
+  # rubocop:disable Rails/Output
+
+  class List
+    attr_reader :section, :kind, :list
+
+    delegate :id, :destroyed?, :update!, :destroy!, :people, to: :list
+
+    def initialize(section, kind)
+      @section = section
+      @kind = kind
+      @list = find_list(section, kind)
+
+      read_people_ids
+    end
+
+    def export(suffix)
+      filename = "#{list.id}-people-#{suffix}.csv"
+      if MailingList.where(id: list.id).exists?
+        Export::SubscriptionsJob.new(:csv, Person.root.id, list.id,
+          {filename: filename}).perform
+      end
+    end
+
+    def subscriptions = list.subscriptions.people
+
+    def read_people_ids = list.people.map(&:id)
+
+    def people_ids = @people_ids ||= read_people_ids
+
+    def subscriptions_counts
+      @subscriptions_counts ||=
+        subscriptions.group(:excluded).count
+          .transform_keys { |key| key ? :excluding : :including }
+    end
+
+    def to_s(refresh = false)
+      @people_ids = nil if refresh
+      @subscriptions_counts = nil if refresh
+
+      list_info = "#{list.group}(#{list.id}, #{kind}, #{list.subscribable_mode}"
+      "#{list_info}): #{people_ids.count} #{subscriptions_counts}"
+    end
+
+    private
+
+    def find_list(section, kind)
+      MailingList
+        .joins(:group)
+        .find_by(internal_key: "sektionsbulletin_#{kind}", groups: {name: section})
+    end
+  end
+
+  def run
+    migrate_bulletins("SAC Weissenstein")
+    migrate_bulletins("SAC Pfannenstiel")
+    migrate_bulletins("SAC Kirchberg") do |paper, digital|
+      digital.subscriptions.excluded.where(subscriber_id: paper.people_ids).destroy_all
+      paper.destroy!
+    end
+  end
+
+  def migrate_bulletins(section, dry_run: true) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+    paper = List.new(section, :paper)
+    digital = List.new(section, :digital)
+
+    print_details_about(digital, paper)
+    paper.export(:before)
+    digital.export(:before)
+    MailingList.transaction do
+      digital.subscriptions.destroy_all
+      paper.subscriptions.destroy_all
+
+      digital.update!(subscribable_mode: :opt_out)
+      paper.update!(subscribable_mode: :opt_in)
+
+      digital_exclusions = digital.read_people_ids - digital.people_ids
+
+      insert_subscription(digital, people_ids: digital_exclusions, excluded: true)
+      insert_subscription(paper, people_ids: paper.people_ids, excluded: false)
+
+      yield paper, digital if block_given?
+      print_details_about(digital, paper, refresh: true)
+      paper.export(:after)
+      digital.export(:after)
+      puts
+      raise ActiveRecord::Rollback if dry_run
+    end
+  end
+
+  def insert_subscription(list, people_ids:, excluded:)
+    attrs = {subscriber_type: "Person", mailing_list_id: list.id, excluded:}
+    rows = people_ids.map { |subscriber_id| attrs.merge(subscriber_id:) }
+    Subscription.insert_all(rows)
+  end
+
+  def print_details_about(*lists, refresh: false)
+    lists.reject(&:destroyed?).each { |list|
+      puts list.to_s(refresh)
+    }
+  end
+  # rubocop:enable Rails/Output
+end

--- a/lib/tty/cli_menu.rb
+++ b/lib/tty/cli_menu.rb
@@ -20,7 +20,8 @@ module TTY
     #   Values are hashes with :description (String) and :action (Proc).
     # @param prompt [String] The prompt message shown before input.
     # @param invalid_choice_message [String] Message for invalid input.
-    def initialize(menu_actions:, prompt: "\nPlease choose an option", invalid_choice_message: "Invalid choice '%s'. Please try again.")
+    def initialize(menu_actions:, prompt: "\nPlease choose an option",
+      invalid_choice_message: "Invalid choice '%s'. Please try again.")
       @menu_actions = add_default_options(menu_actions)
       @prompt = prompt
       @invalid_choice_message = invalid_choice_message
@@ -58,7 +59,10 @@ module TTY
     end
 
     def pry_action
-      {description: "Open pry shell", action: -> { Pry.start }, style: :dim}
+      {description: "Open pry shell", action: -> do
+        puts "def reload! = Rails.application.reloader.reload!"
+        Pry.start
+      end, style: :dim}
     end
 
     # Determines if single-char or multi-char input should be used
@@ -143,11 +147,13 @@ module TTY
 
       @menu_actions.each do |key, config|
         unless key.to_s.present?
-          raise ArgumentError, "Menu action keys must be non-empty Strings (got #{key.class.name} #{key.inspect})"
+          raise ArgumentError,
+            "Menu action keys must be non-empty Strings (got #{key.class.name} #{key.inspect})"
         end
         config_hash = config.deconstruct_keys(nil)
         unless config_hash.key?(:description) && config_hash.key?(:action)
-          raise ArgumentError, "Menu action for key '#{key}' must be a Hash with :description and :action keys"
+          raise ArgumentError,
+            "Menu action for key '#{key}' must be a Hash with :description and :action keys"
         end
         unless config_hash[:description].is_a?(String)
           raise ArgumentError, "Description for key '#{key}' must be a String"

--- a/lib/tty/mailing_lists/swap_bulletin_subscription_modes.rb
+++ b/lib/tty/mailing_lists/swap_bulletin_subscription_modes.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2025, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+module TTY
+  module MailingLists
+    class SwapBulletinSubscriptionModes
+      prepend TTY::Command
+
+      self.description = "Swaps subscriptions modes, see HIT-1448"
+
+      class List
+        attr_reader :section, :kind, :list
+
+        delegate :id, :destroyed?, :update!, :destroy!, :people, to: :list
+
+        def initialize(section, kind)
+          @section = section
+          @kind = kind
+          @list = find_list(section, kind)
+
+          read_people_ids
+        end
+
+        def export(suffix)
+          filename = "#{list.id}-people-#{suffix}.csv"
+          if MailingList.where(id: list.id).exists?
+            Export::SubscriptionsJob.new(:csv, Person.root.id, list.id,
+              {filename: filename}).perform
+          end
+        end
+
+        def subscriptions = list.subscriptions.people
+
+        def read_people_ids = list.people.map(&:id)
+
+        def people_ids = @people_ids ||= read_people_ids
+
+        def subscriptions_counts
+          @subscriptions_counts ||=
+            subscriptions.group(:excluded).count
+              .transform_keys { |key| key ? :excluding : :including }
+        end
+
+        def to_s(refresh = false)
+          @people_ids = nil if refresh
+          @subscriptions_counts = nil if refresh
+
+          list_info = "#{list.group}(#{list.id}, #{kind}, #{list.subscribable_mode}"
+          "#{list_info}): #{people_ids.count} #{subscriptions_counts}"
+        end
+
+        private
+
+        def find_list(section, kind)
+          MailingList
+            .joins(:group)
+            .find_by(internal_key: "sektionsbulletin_#{kind}", groups: {name: section})
+        end
+      end
+
+      def initialize(dry_run: false, export: false)
+        @dry_run = dry_run
+        @export = export
+      end
+
+      def run
+        puts "dry_run: #{dry_run?}, export: #{export?}"
+        migrate_bulletins("SAC Weissenstein")
+        migrate_bulletins("SAC Pfannenstiel")
+        migrate_bulletins("SAC Kirchberg") do |paper, digital|
+          digital.subscriptions.excluded.where(subscriber_id: paper.people_ids).destroy_all
+          paper.destroy!
+        end
+      end
+
+      private
+
+      def migrate_bulletins(section) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
+        paper = List.new(section, :paper)
+        digital = List.new(section, :digital)
+
+        print_details_about(digital, paper, state: :before)
+        MailingList.transaction do
+          digital.subscriptions.destroy_all
+          paper.subscriptions.destroy_all
+
+          digital.update!(subscribable_mode: :opt_out)
+          paper.update!(subscribable_mode: :opt_in)
+
+          digital_exclusions = digital.read_people_ids - digital.people_ids
+
+          insert_subscription(digital, people_ids: digital_exclusions, excluded: true)
+          insert_subscription(paper, people_ids: paper.people_ids, excluded: false)
+
+          yield paper, digital if block_given?
+          print_details_about(digital, paper, refresh: true, state: :after)
+          raise ActiveRecord::Rollback if dry_run?
+        end
+      end
+
+      def dry_run? = @dry_run
+
+      def export? = @export
+
+      def insert_subscription(list, people_ids:, excluded:)
+        attrs = {subscriber_type: "Person", mailing_list_id: list.id, excluded:}
+        rows = people_ids.map { |subscriber_id| attrs.merge(subscriber_id:) }
+        Subscription.insert_all(rows)
+      end
+
+      def print_details_about(*lists, state: :before, refresh: false)
+        lists.reject(&:destroyed?).each { |list|
+          puts list.to_s(refresh)
+          list.export(state) if export?
+        }
+      end
+    end
+  end
+end

--- a/lib/tty/manage_mailing_lists.rb
+++ b/lib/tty/manage_mailing_lists.rb
@@ -21,6 +21,7 @@ module TTY
       "4" => TTY::MailingLists::DigitalBulletinSubscribersWithoutEmail,
       "5" => TTY::MailingLists::CleanupPaperBulletinSubscribersKirchberg,
       "6" => MailingLists::CleanupPilatusBulletins,
+      "7" => MailingLists::SwapBulletinSubscriptionModes
     }.freeze
 
     def run


### PR DESCRIPTION
@daniel-illi was meinst du da dazu? Sobald das script final ist könnte man das auf PROD laufen lassen. Zahlen sehen aktuell wie folgt aus 

```
[157] pry(main)> reload!; include  MigrateList; run
Reloading...
Initializing the Sentry background worker with 7 threads
Initializing the Sentry background worker with 7 threads
SAC Weissenstein(192, paper): 1096 {:including=>1086, :excluding=>589}
SAC Weissenstein(191, digital): 1045 {:including=>1069}
SAC Weissenstein(191, digital): 1045 -> 1089 {:including=>1069} -> {:including=>24, :excluding=>1335}
SAC Weissenstein(192, paper): 1096 {:including=>1086, :excluding=>589}
SAC Pfannenstiel(143, paper): 1374 {:including=>1203, :excluding=>124}
SAC Pfannenstiel(142, digital): 529 {:including=>561}
SAC Pfannenstiel(142, digital): 529 -> 602 {:including=>561} -> {:including=>32, :excluding=>1608}
SAC Pfannenstiel(143, paper): 1374 {:including=>1203, :excluding=>124}
=> nil
```