### PR TITLE
Migrate role start_on for kaiseregg (#2475)

### DIFF
--- a/db/migrate/20260519072001_migrate_role_start_on_for_kaiseregg.rb
+++ b/db/migrate/20260519072001_migrate_role_start_on_for_kaiseregg.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class MigrateRoleStartOnForKaiseregg< ActiveRecord::Migration[8.0]
+  def up
+    execute <<-SQL
+      UPDATE roles
+      SET start_on = '1977-06-10'
+      WHERE group_id = 6395
+        AND start_on = '1978-01-12'
+    SQL
+  end
+end


### PR DESCRIPTION
This could also be done in the console directly but I thought it may be useful to have a migration history for this