### PR TITLE
Override finder methods instead of index (#2418)

### DIFF
--- a/app/controllers/sac_cas/event/application_market_controller.rb
+++ b/app/controllers/sac_cas/event/application_market_controller.rb
@@ -14,19 +14,17 @@ module SacCas::Event::ApplicationMarketController
     delegate :canceled?, to: :event, prefix: true
 
     before_action :set_canceled_flash, only: :index, if: :event_canceled?
-
-    private
-
-    def load_participants
-      super.reorder(SORT_EXPRESSION)
-    end
-
-    def sort_applications(applications)
-      applications.reorder(SORT_EXPRESSION)
-    end
   end
 
   private
+
+  def load_participants
+    super.reorder(SORT_EXPRESSION)
+  end
+
+  def load_applications
+    super.reorder(SORT_EXPRESSION)
+  end
 
   def set_canceled_flash = flash.now[:warning] = t(".event_canceled")
 end

--- a/app/controllers/sac_cas/event/application_market_controller.rb
+++ b/app/controllers/sac_cas/event/application_market_controller.rb
@@ -14,13 +14,16 @@ module SacCas::Event::ApplicationMarketController
     delegate :canceled?, to: :event, prefix: true
 
     before_action :set_canceled_flash, only: :index, if: :event_canceled?
-  end
 
-  def index
-    @participants = load_participants.reorder(SORT_EXPRESSION)
-    @applications = Event::ParticipationDecorator.decorate_collection(
-      load_applications.order(SORT_EXPRESSION)
-    )
+    private
+
+    def load_participants
+      super.reorder(SORT_EXPRESSION)
+    end
+
+    def sort_applications(applications)
+      applications.reorder(SORT_EXPRESSION)
+    end
   end
 
   private


### PR DESCRIPTION
Overriding index without calling super broke all formats besides html. Overriding the finder methods here is much cleaner anyway.