### PR TITLE
Use column instead of public column for sac remark table displays (#2415)

### DIFF
--- a/app/controllers/sac_cas/people_controller.rb
+++ b/app/controllers/sac_cas/people_controller.rb
@@ -26,6 +26,10 @@ module SacCas::PeopleController
 
   private
 
+  def filter_entries
+    super.includes(groups: :layer_group)
+  end
+
   def registrations_for_approval?
     group.is_a?(Group::SektionsNeuanmeldungenSektion)
   end

--- a/app/domain/table_displays/people/duplicate_exists_column.rb
+++ b/app/domain/table_displays/people/duplicate_exists_column.rb
@@ -13,6 +13,10 @@ module TableDisplays::People
       end
     end
 
+    def required_model_includes(attr)
+      [:person_duplicates_as_p1, :person_duplicates_as_p2]
+    end
+
     def required_permission(attr)
       :show
     end
@@ -24,7 +28,8 @@ module TableDisplays::People
     end
 
     def duplicate_exists(person)
-      person.person_duplicates.reject(&:ignore).any? ? I18n.t(:"global.yes") : I18n.t(:"global.no")
+      (person.person_duplicates_as_p1 + person.person_duplicates_as_p2).reject(&:ignore).any? ?
+        I18n.t(:"global.yes") : I18n.t(:"global.no")
     end
   end
 end

--- a/app/domain/table_displays/people/sac_remark_national_office_column.rb
+++ b/app/domain/table_displays/people/sac_remark_national_office_column.rb
@@ -6,7 +6,13 @@
 #  https://github.com/hitobito/hitobito_sac_cas
 
 module TableDisplays::People
-  class SacRemarkNationalOfficeColumn < TableDisplays::PublicColumn
+  class SacRemarkNationalOfficeColumn < TableDisplays::Column
+    def render(attr)
+      super do |target, target_attr|
+        template.format_attr(target, target_attr) if target.respond_to?(target_attr)
+      end
+    end
+
     def required_model_attrs(attr)
       [:sac_remark_national_office]
     end

--- a/app/domain/table_displays/people/sac_remark_section_column.rb
+++ b/app/domain/table_displays/people/sac_remark_section_column.rb
@@ -6,10 +6,21 @@
 #  https://github.com/hitobito/hitobito_sac_cas
 
 module TableDisplays::People
-  class SacRemarkSectionColumn < TableDisplays::PublicColumn
+  class SacRemarkSectionColumn < TableDisplays::Column
+    def render(attr)
+      super do |target, target_attr|
+        template.format_attr(target, target_attr) if target.respond_to?(target_attr)
+      end
+    end
+
     def required_model_attrs(attr)
-      [:sac_remark_section_1, :sac_remark_section_2, :sac_remark_section_3, :sac_remark_section_4,
-        :sac_remark_section_5]
+      [
+        :sac_remark_section_1,
+        :sac_remark_section_2,
+        :sac_remark_section_3,
+        :sac_remark_section_4,
+        :sac_remark_section_5
+      ]
     end
 
     def required_permission(attr)

--- a/app/domain/table_displays/people/sektion_member_admin_visible.rb
+++ b/app/domain/table_displays/people/sektion_member_admin_visible.rb
@@ -9,22 +9,8 @@ module TableDisplays::People
   module SektionMemberAdminVisible
     # Allow Sektions Admin to view tables even though person no longer
     # has an active role in that sektion
-    #
-    # Since https://github.com/hitobito/hitobito/commit/80aa972cd6f8f26342d0318099b034c592462145
-    # this could in theory also be achieved using standard ability checks (as ended roles are taken
-    # into account) but as Group::SektionsFunktionaere::Mitgliederverwaltung has no permissions at
-    # all we stick with this solution
-
-    # this required_model_includes could be removed if we relied solely on our abilities
-    def required_model_includes(_attr)
-      super + unscoped_person_roles_includes
-    end
 
     private
-
-    def unscoped_person_roles_includes
-      (@model_class == Person) ? [roles_unscoped: :group] : [participant: [roles_unscoped: :group]]
-    end
 
     def allowed?(object, attr, _original_object, _original_attr)
       super || (section_admin_layer_ids & object_membership_layer_ids(object)).any?
@@ -37,7 +23,7 @@ module TableDisplays::People
     end
 
     def section_admin_layer_ids
-      ability.user.roles.includes(:group).select do |role|
+      ability.user.roles.select do |role|
         SacCas::SAC_SECTION_MEMBER_ADMIN_ROLE_TYPES.include?(role.class)
       end.map { |role| role.group.layer_group_id }
     end

--- a/app/domain/table_displays/people/self_registration_reason_column.rb
+++ b/app/domain/table_displays/people/self_registration_reason_column.rb
@@ -9,6 +9,10 @@ module TableDisplays::People
   class SelfRegistrationReasonColumn < TableDisplays::Column
     prepend TableDisplays::People::SektionMemberAdminVisible
 
+    def required_model_includes(_attr)
+      [self_registration_reason: :translations]
+    end
+
     def required_model_attrs(attr)
       [:self_registration_reason_id]
     end

--- a/app/domain/table_displays/people/termination_column.rb
+++ b/app/domain/table_displays/people/termination_column.rb
@@ -18,7 +18,7 @@ module TableDisplays::People
     end
 
     def required_model_includes(attr)
-      [:roles_with_ended_readable]
+      [:groups, :roles_with_ended_readable]
     end
 
     def render(attr)

--- a/app/domain/table_displays/people/termination_reason_column.rb
+++ b/app/domain/table_displays/people/termination_reason_column.rb
@@ -7,6 +7,10 @@
 
 module TableDisplays::People
   class TerminationReasonColumn < TerminationColumn
+    def required_model_includes(attr)
+      super + [roles_unscoped: {termination_reason: :translations}]
+    end
+
     def value(terminated_role)
       terminated_role.termination_reason_text
     end

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas
+
+# termination_reason is an optional belongs_to on an STI model.
+# Some role types do not have a termination reason, so Bullet reports this as unused for those STI subclasses.
+# To prevent N+1 queries we want to preload this for any role type and don't want a warning
+# for every role type in the list without a record with termination reason
+Rails.application.config.after_initialize do
+  if defined? Bullet
+    Role.all_types.map(&:to_s).each do
+      Bullet.add_safelist(
+        type: :unused_eager_loading,
+        class_name: _1,
+        association: :termination_reason
+      )
+    end
+  end
+end

--- a/spec/domain/table_displays/people/sac_remark_national_office_column_spec.rb
+++ b/spec/domain/table_displays/people/sac_remark_national_office_column_spec.rb
@@ -16,9 +16,9 @@ describe TableDisplays::People::SacRemarkNationalOfficeColumn, type: :helper do
   let(:table) { StandardTableBuilder.new([person], self) }
 
   before do
-    # rubocop:todo Layout/LineLength
-    allow_any_instance_of(ActionView::Base).to receive(:parent).and_return(groups(:bluemlisalp_mitglieder))
-    # rubocop:enable Layout/LineLength
+    allow_any_instance_of(ActionView::Base)
+      .to receive(:parent)
+      .and_return(groups(:bluemlisalp_mitglieder))
     people(:mitglied).update_column(:sac_remark_national_office, "Bemerkung von Geschäfststelle")
   end
 
@@ -28,4 +28,20 @@ describe TableDisplays::People::SacRemarkNationalOfficeColumn, type: :helper do
     value: "Bemerkung von Geschäfststelle",
     permission: :manage_national_office_remark
   }
+
+  context "as sektion admin" do
+    let(:sektion_admin) do
+      Fabricate(
+        Group::SektionsMitglieder::Schreibrecht.sti_name.to_sym,
+        group: groups(:bluemlisalp_mitglieder)
+      ).person
+    end
+
+    # Regression spec from this column previously inheriting from PublicColumn with SektionMemberAdminVisible
+    it "is not visible to a section admin without manage_national_office_remark" do
+      display = described_class.new(Ability.new(sektion_admin), table: table, model_class: Person)
+
+      expect(display.value_for(people(:mitglied), :sac_remark_national_office)).to eq "fehlende Berechtigung"
+    end
+  end
 end

--- a/spec/domain/table_displays/people/sac_remark_section_column_spec.rb
+++ b/spec/domain/table_displays/people/sac_remark_section_column_spec.rb
@@ -60,4 +60,20 @@ describe TableDisplays::People::SacRemarkSectionColumn, type: :helper do
     value: "Bemerkung von Sektion 5",
     permission: :manage_section_remarks
   }
+
+  context "as sektion admin" do
+    let(:sektion_admin) do
+      Fabricate(
+        Group::SektionsMitglieder::Schreibrecht.sti_name.to_sym,
+        group: groups(:bluemlisalp_mitglieder)
+      ).person
+    end
+
+    # Regression spec from this column previously inheriting from PublicColumn with SektionMemberAdminVisible
+    it "is not visible to a section admin without manage_national_office_remark" do
+      display = described_class.new(Ability.new(sektion_admin), table: table, model_class: Person)
+
+      expect(display.value_for(people(:mitglied), :sac_remark_section_1)).to eq "fehlende Berechtigung"
+    end
+  end
 end

--- a/spec/domain/table_displays/people/sektion_member_admin_visible_spec.rb
+++ b/spec/domain/table_displays/people/sektion_member_admin_visible_spec.rb
@@ -27,10 +27,7 @@ describe TableDisplays::People::SektionMemberAdminVisible, type: :helper do
     travel_to(Date.new(2025, 3, 10))
   end
 
-  [
-    [Person, [:roles_with_ended_readable, {roles_unscoped: :group}]],
-    [Event::Participation, [:roles_with_ended_readable, participant: [{roles_unscoped: :group}]]]
-  ].each do |model_class, expected_includes|
+  [Person, Event::Participation].each do |model_class|
     context "table display on #{model_class}" do
       subject(:column) {
         TableDisplays::People::TerminateOnColumn.new(ability, model_class: model_class)
@@ -90,10 +87,6 @@ describe TableDisplays::People::SektionMemberAdminVisible, type: :helper do
         end
       end
 
-      it "only includes needed associations" do
-        expect(column.required_model_includes(:terminated_on)).to eq expected_includes
-      end
-
       describe "columns including or excluding" do
         [
           "beitrittsdatum",
@@ -109,12 +102,6 @@ describe TableDisplays::People::SektionMemberAdminVisible, type: :helper do
           "language",
           "membership_years",
           "nationality_j_s",
-          "sac_remark_national_office",
-          "sac_remark_section_1",
-          "sac_remark_section_2",
-          "sac_remark_section_3",
-          "sac_remark_section_4",
-          "sac_remark_section_5",
           "self_registration_reason",
           "terminate_on",
           "termination_reason",


### PR DESCRIPTION
The issue is not that straight forward, the solution is pretty simple though, basically it does not make sense to inherit from PublicColumn, when we override the `required_permission` anyways.

The reason it actually showed the columns was never the permission or the permission check itself in column.rb. We prepend `TableDisplays::People::SektionMemberAdminVisible` to `PublicColumn` in wagon.rb. This module overrides the allowed? method and actually allows member to see columns they are usually not allowed to. This should not apply to the sac remark columns tho.