### PR TITLE
Add onboarding mails for sektionsfunktionaere (#2407)

### DIFF
--- a/app/controllers/sac_cas/roles_controller.rb
+++ b/app/controllers/sac_cas/roles_controller.rb
@@ -14,6 +14,21 @@ module SacCas::RolesController
 
   private
 
+  def assign_attributes
+    super
+    assign_send_onboarding_mail(entry)
+  end
+
+  def build_new_type
+    super.tap { |role| assign_send_onboarding_mail(role) }
+  end
+
+  def assign_send_onboarding_mail(role)
+    return unless role.respond_to?(:send_onboarding_mail)
+
+    role.send_onboarding_mail = params[:send_onboarding_mail]
+  end
+
   def resolve_household_for_neuanmeldung
     destroy_family_neuanmeldungen if family_neuanmeldungs_role?
     destroy_household if neuanmeldungs_stammsektion_role?

--- a/app/domain/sac_cas.rb
+++ b/app/domain/sac_cas.rb
@@ -129,6 +129,8 @@ module SacCas
   ###
 
   MV_EMAIL = "mv@sac-cas.ch"
+  JUGEND_EMAIL = "jugend@sac-cas.ch"
+  HUETTEN_EMAIL = "huetten@sac-cas.ch"
   MAILING_LIST_SAC_NEWSLETTER_INTERNAL_KEY = "sac_newsletter"
   MAILING_LIST_SAC_INSIDE_INTERNAL_KEY = "sac_inside"
   MAILING_LIST_TOURENLEITER_INTERNAL_KEY = "tourenleiter"

--- a/app/helpers/sac_cas/roles_helper.rb
+++ b/app/helpers/sac_cas/roles_helper.rb
@@ -6,6 +6,14 @@
 #  https://github.com/hitobito/hitobito_sac_cas
 
 module SacCas::RolesHelper
+  def roles_type_options(group, entry)
+    super.map { |label, type|
+      onboarding_mail = type&.safe_constantize&.include?(Roles::SektionsfunktionaereOnboardingMails)
+
+      [label, type, {data: {show_onboarding_mail: onboarding_mail}}]
+    }
+  end
+
   def format_role_membership_years(role)
     f(role.membership_years.floor) if role.is_a?(Group::SektionsMitglieder::Mitglied)
   end

--- a/app/mailers/concerns/common_mailer_placeholders.rb
+++ b/app/mailers/concerns/common_mailer_placeholders.rb
@@ -6,6 +6,10 @@
 #  https://github.com/hitobito/hitobito_sac_cas.
 
 module CommonMailerPlaceholders
+  def placeholder_person_id
+    @person.id
+  end
+
   def placeholder_first_name
     @person.first_name
   end

--- a/app/mailers/people/sektionsfunktionaere_mailer.rb
+++ b/app/mailers/people/sektionsfunktionaere_mailer.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class People::SektionsfunktionaereMailer < ApplicationMailer
+  include CommonMailerPlaceholders
+
+  ONBOARDING_PRAESIDIUM = "sektions_funktionaere_onboarding_praesidium"
+  ONBOARDING_MITGLIEDERVERWALTUNG = "sektions_funktionaere_onboarding_mitgliederverwaltung"
+  ONBOARDING_ADMINISTRATION = "sektions_funktionaere_onboarding_administration"
+  ONBOARDING_REDAKTION = "sektions_funktionaere_onboarding_redaktion"
+  ONBOARDING_KULTURBEAUFTRAGTER = "sektions_funktionaere_onboarding_kulturbeauftragter"
+  ONBOARDING_UMWELTBEAUFTRAGTER = "sektions_funktionaere_onboarding_umweltbeauftragter"
+  ONBOARDING_TOURENCHEF = "sektions_funktionaere_onboarding_tourenchef"
+  ONBOARDING_TOURENLEITER = "sektions_funktionaere_onboarding_tourenleiter"
+  ONBOARDING_KIBE_CHEF = "sektions_funktionaere_onboarding_kibe_chef"
+  ONBOARDING_FABE_CHEF = "sektions_funktionaere_onboarding_fabe_chef"
+  ONBOARDING_JO_CHEF = "sektions_funktionaere_onboarding_jo_chef"
+  ONBOARDING_HUETTENOBMANN = "sektions_funktionaere_onboarding_huettenobmann"
+  ONBOARDING_HUETTENCHEF = "sektions_funktionaere_onboarding_huettenchef"
+  ONBOARDING_HUETTENWART = "sektions_funktionaere_onboarding_huettenwart"
+
+  def praesidium_onboarding(role)
+    send_mail(role, ONBOARDING_PRAESIDIUM, SacCas::MV_EMAIL)
+  end
+  alias_method :co_praesidium_onboarding, :praesidium_onboarding
+  alias_method :vize_praesidium_onboarding, :praesidium_onboarding
+  alias_method :praesidium_ortsgruppe_onboarding, :praesidium_onboarding
+  alias_method :co_praesidium_ortsgruppe_onboarding, :praesidium_onboarding
+  alias_method :vize_praesidium_ortsgruppe_onboarding, :praesidium_onboarding
+
+  def mitgliederverwaltung_onboarding(role)
+    send_mail(role, ONBOARDING_MITGLIEDERVERWALTUNG, SacCas::MV_EMAIL)
+  end
+
+  def administration_onboarding(role)
+    send_mail(role, ONBOARDING_ADMINISTRATION, SacCas::MV_EMAIL)
+  end
+
+  def redaktion_onboarding(role)
+    send_mail(role, ONBOARDING_REDAKTION, SacCas::MV_EMAIL)
+  end
+
+  def kulturbeauftragter_onboarding(role)
+    send_mail(role, ONBOARDING_KULTURBEAUFTRAGTER, SacCas::MV_EMAIL)
+  end
+
+  def umweltbeauftragter_onboarding(role)
+    send_mail(role, ONBOARDING_UMWELTBEAUFTRAGTER, SacCas::MV_EMAIL)
+  end
+
+  def huettenobmann_onboarding(role)
+    send_mail(role, ONBOARDING_HUETTENOBMANN, SacCas::HUETTEN_EMAIL)
+  end
+
+  def tourenchef_onboarding(role)
+    send_mail(role, ONBOARDING_TOURENCHEF, Group.root.course_admin_email)
+  end
+  alias_method :tourenchef_sommer_onboarding, :tourenchef_onboarding
+  alias_method :tourenchef_winter_onboarding, :tourenchef_onboarding
+
+  def tourenleiter_onboarding(role)
+    send_mail(role, ONBOARDING_TOURENLEITER, Group.root.course_admin_email)
+  end
+  alias_method :tourenleiter_ohne_qualifikation_onboarding, :tourenleiter_onboarding
+
+  def kibe_chef_onboarding(role)
+    send_mail(role, ONBOARDING_KIBE_CHEF, SacCas::JUGEND_EMAIL)
+  end
+
+  def fabe_chef_onboarding(role)
+    send_mail(role, ONBOARDING_FABE_CHEF, SacCas::JUGEND_EMAIL)
+  end
+
+  def jo_chef_onboarding(role)
+    send_mail(role, ONBOARDING_JO_CHEF, SacCas::JUGEND_EMAIL)
+  end
+
+  def huettenchef_onboarding(role)
+    send_mail(role, ONBOARDING_HUETTENCHEF, SacCas::HUETTEN_EMAIL)
+  end
+
+  def huettenwart_onboarding(role)
+    send_mail(role, ONBOARDING_HUETTENWART, SacCas::HUETTEN_EMAIL)
+  end
+
+  private
+
+  def send_mail(role, content_key, bcc)
+    @role = role
+    @person = role.person
+    headers[:bcc] = [bcc].compact_blank
+
+    I18n.with_locale(@person.language) do
+      compose(@person.email, content_key)
+    end
+  end
+
+  def placeholder_role_name
+    @role.class.model_name.human
+  end
+
+  def placeholder_role_start
+    return unless @role.start_on
+
+    I18n.l(@role.start_on)
+  end
+
+  def placeholder_role_end
+    return unless @role.end_on
+
+    I18n.l(@role.end_on)
+  end
+
+  def placeholder_role_group
+    @role.group
+  end
+
+  def placeholder_role_sektion
+    @role.layer_group
+  end
+end

--- a/app/models/concerns/roles/sektionsfunktionaere_onboarding_mails.rb
+++ b/app/models/concerns/roles/sektionsfunktionaere_onboarding_mails.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Roles::SektionsfunktionaereOnboardingMails
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :send_onboarding_mail
+    after_save :deliver_onboarding_mail, if: :send_onboarding_mail
+  end
+
+  private
+
+  def deliver_onboarding_mail
+    method_name = :"#{self.class.name.demodulize.underscore}_onboarding"
+    People::SektionsfunktionaereMailer.send(method_name, self).deliver_later
+  end
+end

--- a/app/models/group/sac_cas_clubhuette.rb
+++ b/app/models/group/sac_cas_clubhuette.rb
@@ -8,11 +8,13 @@
 class Group::SacCasClubhuette < ::Group
   ### ROLES
   class Huettenwart < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end
 
   class Huettenchef < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end

--- a/app/models/group/sektions_clubhuette.rb
+++ b/app/models/group/sektions_clubhuette.rb
@@ -8,11 +8,13 @@
 class Group::SektionsClubhuette < ::Group
   ### ROLES
   class Huettenwart < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end
 
   class Huettenchef < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end

--- a/app/models/group/sektions_funktionaere.rb
+++ b/app/models/group/sektions_funktionaere.rb
@@ -23,33 +23,41 @@ class Group::SektionsFunktionaere < ::Group
 
   ### ROLES
   class Praesidium < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.basic_permissions_only = true
   end
 
   class CoPraesidium < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.basic_permissions_only = true
   end
 
   class VizePraesidium < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.basic_permissions_only = true
   end
 
   class PraesidiumOrtsgruppe < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.basic_permissions_only = true
   end
 
   class CoPraesidiumOrtsgruppe < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.basic_permissions_only = true
   end
 
   class VizePraesidiumOrtsgruppe < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.basic_permissions_only = true
   end
 
   class Mitgliederverwaltung < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
   end
 
   class Administration < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = [:layer_and_below_full]
     self.two_factor_authentication_enforced = true
   end
@@ -60,6 +68,7 @@ class Group::SektionsFunktionaere < ::Group
   end
 
   class Kulturbeauftragter < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end
@@ -69,10 +78,12 @@ class Group::SektionsFunktionaere < ::Group
   end
 
   class Redaktion < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
   end
 
   class Huettenobmann < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end
@@ -88,6 +99,7 @@ class Group::SektionsFunktionaere < ::Group
   end
 
   class Umweltbeauftragter < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end

--- a/app/models/group/sektions_touren_und_kurse.rb
+++ b/app/models/group/sektions_touren_und_kurse.rb
@@ -12,6 +12,7 @@ class Group::SektionsTourenUndKurse < Group
   ### ROLES
 
   class TourenleiterOhneQualifikation < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = [:layer_created_events_full]
   end
 
@@ -29,6 +30,7 @@ class Group::SektionsTourenUndKurse < Group
   end
 
   class TourenchefSommer < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.two_factor_authentication_enforced = true
     self.permissions = [
       :group_and_below_full,
@@ -39,6 +41,7 @@ class Group::SektionsTourenUndKurse < Group
   end
 
   class TourenchefWinter < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.two_factor_authentication_enforced = true
     self.permissions = [
       :group_and_below_full,
@@ -49,6 +52,7 @@ class Group::SektionsTourenUndKurse < Group
   end
 
   class Tourenchef < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.two_factor_authentication_enforced = true
     self.permissions = [
       :group_and_below_full,
@@ -59,16 +63,19 @@ class Group::SektionsTourenUndKurse < Group
   end
 
   class KibeChef < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end
 
   class FabeChef < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end
 
   class JoChef < ::Role
+    include Roles::SektionsfunktionaereOnboardingMails
     self.permissions = []
     self.basic_permissions_only = true
   end

--- a/app/views/roles/_type_fields_sac_cas.html.haml
+++ b/app/views/roles/_type_fields_sac_cas.html.haml
@@ -13,3 +13,9 @@
                                 multiple: true,
                                 data: { chosen_no_results: t("global.chosen_no_results"),
                                         controller: "tom-select" } })
+
+%div{ data: { controller: "field-visibility", "field-visibility-dependent-id-value": "role_type", "field-visibility-show-when-data-value": "showOnboardingMail" } }
+    .row.mb-2{ class: "hidden", data: { "field-visibility-target": "container" } }
+        .offset-2
+            = check_box_tag(:send_onboarding_mail, true, entry.new_record?, class: "form-check-input")
+            %span.ms-1= t(".send_onboarding_mail")

--- a/app/views/roles/_type_fields_sac_cas.html.haml
+++ b/app/views/roles/_type_fields_sac_cas.html.haml
@@ -14,8 +14,8 @@
                                 data: { chosen_no_results: t("global.chosen_no_results"),
                                         controller: "tom-select" } })
 
-%div{ data: { controller: "field-visibility", "field-visibility-dependent-id-value": "role_type", "field-visibility-show-when-data-value": "showOnboardingMail" } }
+%div{ data: { controller: "field-visibility", "field-visibility-observed-field-id-value": "role_type", "field-visibility-show-when-data-value": "showOnboardingMail" } }
     .row.mb-2{ class: "hidden", data: { "field-visibility-target": "container" } }
         .offset-2
             = check_box_tag(:send_onboarding_mail, true, entry.new_record?, class: "form-check-input")
-            %span.ms-1= t(".send_onboarding_mail")
+            = label_tag :send_onboarding_mail, t(".send_onboarding_mail")

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -2542,6 +2542,8 @@ de:
       adult: Einzel
       youth: Jugend
       family: Familie
+    type_fields_sac_cas:
+      send_onboarding_mail: Willkommensnachricht schicken
 
   roles/change_zusatzsektion_to_family:
     link: Wechsel Familie

--- a/db/seeds/custom_contents.rb
+++ b/db/seeds/custom_contents.rb
@@ -169,6 +169,27 @@ CustomContent.seed(:key,
    placeholders_optional: "person-id, first-name, last-name, profile-url, " \
     "role-name, role-start, role-end, role-group, role-sektion"})
 
+sektionsfunktionaere_onboarding_body =
+  "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+  "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+  " bei {role-sektion} willkommen zu heissen." \
+  "<br><br>" \
+  "Wichtige Links: <br>" \
+  "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+  "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+  "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+  "{profile-url} <br>" \
+  "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+  "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+  "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+  "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+  "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+  "<br><br>" \
+  "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+  " herzlichst für deine ehrenamtliche Arbeit!" \
+  "<br><br>" \
+  "Bergsportliche Grüsse"
+
 CustomContent::Translation.seed_once(:custom_content_id, :locale,
   {custom_content_id:
      CustomContent.get(Event::CourseParticipationMailer::REJECT_APPLIED_PARTICIPATION).id,
@@ -653,347 +674,95 @@ CustomContent::Translation.seed_once(:custom_content_id, :locale,
    locale: "de",
    label: "Onboarding: Präsidium",
    subject: "Onboarding: Präsidium",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_MITGLIEDERVERWALTUNG
   ).id,
    locale: "de",
    label: "Onboarding: Mitgliederverwaltung",
    subject: "Onboarding: Mitgliederverwaltung",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_ADMINISTRATION
   ).id,
    locale: "de",
    label: "Onboarding: Administration",
    subject: "Onboarding: Administration",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_REDAKTION
   ).id,
    locale: "de",
    label: "Onboarding: Redaktion",
    subject: "Onboarding: Redaktion",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_KULTURBEAUFTRAGTER
   ).id,
    locale: "de",
    label: "Onboarding: Kulturbeauftragter",
    subject: "Onboarding: Kulturbeauftragter",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_UMWELTBEAUFTRAGTER
   ).id,
    locale: "de",
    label: "Onboarding: Umweltbeauftragter",
    subject: "Onboarding: Umweltbeauftragter",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_TOURENCHEF
   ).id,
    locale: "de",
    label: "Onboarding: Tourenchef",
    subject: "Onboarding: Tourenchef",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_TOURENLEITER
   ).id,
    locale: "de",
    label: "Onboarding: Tourenleiter",
    subject: "Onboarding: Tourenleiter",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_KIBE_CHEF
   ).id,
    locale: "de",
    label: "Onboarding: KiBe-Chef",
    subject: "Onboarding: KiBe-Chef",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_FABE_CHEF
   ).id,
    locale: "de",
    label: "Onboarding: FaBe-Chef",
    subject: "Onboarding: FaBe-Chef",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_JO_CHEF
   ).id,
    locale: "de",
    label: "Onboarding: JO-Chef",
    subject: "Onboarding: JO-Chef",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_HUETTENOBMANN
   ).id,
    locale: "de",
    label: "Onboarding: Huettenobmann",
    subject: "Onboarding: Huettenobmann",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_HUETTENCHEF
   ).id,
    locale: "de",
    label: "Onboarding: Huettenchef",
    subject: "Onboarding: Huettenchef",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"},
+   body: sektionsfunktionaere_onboarding_body},
   {custom_content_id: CustomContent.get(
     People::SektionsfunktionaereMailer::ONBOARDING_HUETTENWART
   ).id,
    locale: "de",
    label: "Onboarding: Huettenwart",
    subject: "Onboarding: Huettenwart",
-   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
-    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
-    " bei {role-sektion} willkommen zu heissen." \
-    "<br><br>" \
-    "Wichtige Links: <br>" \
-    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
-    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
-    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
-    "{profile-url} <br>" \
-    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
-    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
-    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
-    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
-    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
-    "<br><br>" \
-    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
-    " herzlichst für deine ehrenamtliche Arbeit!" \
-    "<br><br>" \
-    "Bergsportliche Grüsse"})
+   body: sektionsfunktionaere_onboarding_body})

--- a/db/seeds/custom_contents.rb
+++ b/db/seeds/custom_contents.rb
@@ -125,7 +125,49 @@ CustomContent.seed(:key,
    placeholders_required: "first-name, sektion-name",
    placeholders_optional: "profile-url, profile-links"},
   {key: People::NeuanmeldungenMailer::REJECTED,
-   placeholders_required: "first-name, sektion-name"})
+   placeholders_required: "first-name, sektion-name"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_PRAESIDIUM,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_MITGLIEDERVERWALTUNG,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_ADMINISTRATION,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_REDAKTION,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_KULTURBEAUFTRAGTER,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_UMWELTBEAUFTRAGTER,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_TOURENCHEF,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_TOURENLEITER,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_KIBE_CHEF,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_FABE_CHEF,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_JO_CHEF,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_HUETTENOBMANN,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_HUETTENCHEF,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"},
+  {key: People::SektionsfunktionaereMailer::ONBOARDING_HUETTENWART,
+   placeholders_optional: "person-id, first-name, last-name, profile-url, " \
+    "role-name, role-start, role-end, role-group, role-sektion"})
 
 CustomContent::Translation.seed_once(:custom_content_id, :locale,
   {custom_content_id:
@@ -604,4 +646,354 @@ CustomContent::Translation.seed_once(:custom_content_id, :locale,
     "Somit empfehlen wir dir, deinen Antrag an eine andere Sektion deiner Wahl zu stellen." \
     "<br><br>" \
     "Vielen Dank für dein Verständnis.<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_PRAESIDIUM
+  ).id,
+   locale: "de",
+   label: "Onboarding: Präsidium",
+   subject: "Onboarding: Präsidium",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_MITGLIEDERVERWALTUNG
+  ).id,
+   locale: "de",
+   label: "Onboarding: Mitgliederverwaltung",
+   subject: "Onboarding: Mitgliederverwaltung",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_ADMINISTRATION
+  ).id,
+   locale: "de",
+   label: "Onboarding: Administration",
+   subject: "Onboarding: Administration",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_REDAKTION
+  ).id,
+   locale: "de",
+   label: "Onboarding: Redaktion",
+   subject: "Onboarding: Redaktion",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_KULTURBEAUFTRAGTER
+  ).id,
+   locale: "de",
+   label: "Onboarding: Kulturbeauftragter",
+   subject: "Onboarding: Kulturbeauftragter",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_UMWELTBEAUFTRAGTER
+  ).id,
+   locale: "de",
+   label: "Onboarding: Umweltbeauftragter",
+   subject: "Onboarding: Umweltbeauftragter",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_TOURENCHEF
+  ).id,
+   locale: "de",
+   label: "Onboarding: Tourenchef",
+   subject: "Onboarding: Tourenchef",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_TOURENLEITER
+  ).id,
+   locale: "de",
+   label: "Onboarding: Tourenleiter",
+   subject: "Onboarding: Tourenleiter",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_KIBE_CHEF
+  ).id,
+   locale: "de",
+   label: "Onboarding: KiBe-Chef",
+   subject: "Onboarding: KiBe-Chef",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_FABE_CHEF
+  ).id,
+   locale: "de",
+   label: "Onboarding: FaBe-Chef",
+   subject: "Onboarding: FaBe-Chef",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_JO_CHEF
+  ).id,
+   locale: "de",
+   label: "Onboarding: JO-Chef",
+   subject: "Onboarding: JO-Chef",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_HUETTENOBMANN
+  ).id,
+   locale: "de",
+   label: "Onboarding: Huettenobmann",
+   subject: "Onboarding: Huettenobmann",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_HUETTENCHEF
+  ).id,
+   locale: "de",
+   label: "Onboarding: Huettenchef",
+   subject: "Onboarding: Huettenchef",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
+    "Bergsportliche Grüsse"},
+  {custom_content_id: CustomContent.get(
+    People::SektionsfunktionaereMailer::ONBOARDING_HUETTENWART
+  ).id,
+   locale: "de",
+   label: "Onboarding: Huettenwart",
+   subject: "Onboarding: Huettenwart",
+   body: "Hallo {first-name} {last-name} ({person-id})<br><br>" \
+    "Wir freuen uns sehr, dich in deiner neuen Rolle als {role-name} der {role-group}" \
+    " bei {role-sektion} willkommen zu heissen." \
+    "<br><br>" \
+    "Wichtige Links: <br>" \
+    "- Die Anleitungen zur Bedienung des SAC-Portals findest du hier: " \
+    "https://saccas.atlassian.net/wiki/spaces/DOC/pages/4343693318/SAC-Portal <br>" \
+    "- Dein Benutzerprofil im SAC-Portal kannst du hier einsehen und bearbeiten: " \
+    "{profile-url} <br>" \
+    "- Falls du in deiner Funktion Zugriff auf unser Extranet erhalten hast, " \
+    "kannst du über folgenden Link auf SAC-Inside zugreifen: " \
+    "https://www.sac-cas.ch/de/mein-sac/sac-inside/ <br>" \
+    "- Bei Fragen bitten wir dich über ein Ticket an uns zu wenden: " \
+    "https://service.portal.sac-cas.ch/servicedesk/customer/portal/4/group/-1" \
+    "<br><br>" \
+    "Wir wünschen dir viel Freude in deiner neuen Funktion und bedanken uns" \
+    " herzlichst für deine ehrenamtliche Arbeit!" \
+    "<br><br>" \
     "Bergsportliche Grüsse"})

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -10,7 +10,7 @@ describe RolesController do
 
   let(:person) { Fabricate(:person) }
 
-  describe "POST create" do
+  describe "POST#create" do
     context "FreigabeKomitee::Pruefer" do
       it "correctly assigns approval_kinds" do
         assigned_approval_kinds = [event_approval_kinds(:professional), event_approval_kinds(:security)]
@@ -32,9 +32,62 @@ describe RolesController do
         expect(role.approval_kinds).to match_array(assigned_approval_kinds)
       end
     end
+
+    context "Sektionsfuntionaere" do
+      let(:group) { groups(:bluemlisalp_funktionaere) }
+      let(:role_type) { Group::SektionsFunktionaere::Praesidium.sti_name }
+
+      it "send onboarding mail if send_onboarding_mail is true" do
+        expect {
+          post :create, params: {
+            group_id: group.id,
+            send_onboarding_mail: true,
+            role: {group_id: group.id, person_id: person.id, type: role_type}
+          }
+        }.to have_enqueued_mail(People::SektionsfunktionaereMailer, :praesidium_onboarding)
+      end
+
+      it "does not send onboarding mail if send_onboarding_mail is false" do
+        expect {
+          post :create, params: {
+            group_id: group.id,
+            role: {group_id: group.id, person_id: person.id, type: role_type}
+          }
+        }.not_to have_enqueued_mail
+      end
+    end
   end
 
-  describe "DELETE destroy" do
+  describe "PUT#update" do
+    context "Sektionsfuntionaere" do
+      let(:group) { groups(:bluemlisalp_funktionaere) }
+      let(:role_type) { Group::SektionsFunktionaere::Praesidium.sti_name }
+      let(:role) { Fabricate(role_type.to_sym, group:, person:) }
+
+      it "sends onboarding mail if send_onboarding_mail is true" do
+        expect {
+          patch :update, params: {
+            group_id: group.id,
+            id: role.id,
+            send_onboarding_mail: true,
+            role: {group_id: group.id, person_id: person.id, type: role_type}
+          }
+        }.to have_enqueued_mail(People::SektionsfunktionaereMailer, :praesidium_onboarding)
+      end
+
+      it "does not send onboarding mail if send_onboarding_mail is false" do
+        expect {
+          patch :update, params: {
+            group_id: group.id,
+            id: role.id,
+            role: {group_id: group.id, person_id: person.id, type: role_type}
+          }
+        }.not_to have_enqueued_mail
+      end
+    end
+  end
+
+  describe "DELETE#destroy" do
     let!(:household) do
       household = Household.new(person, maintain_sac_family: false, validate_members: false)
       household.set_family_main_person!

--- a/spec/features/roles_controller_spec.rb
+++ b/spec/features/roles_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe RolesController, js: true do
+  let(:admin) { people(:admin) }
+  let(:group) { groups(:bluemlisalp_funktionaere) }
+  let(:role) { Fabricate(Group::SektionsFunktionaere::Leserecht.sti_name, group:) }
+
+  before { sign_in(admin) }
+
+  def choose_role(label)
+    find("#role_type_select #role_type").find("option", exact_text: label).click
+  end
+
+  context "new" do
+    before { visit new_group_role_path(group_id: group.id) }
+
+    describe "onboarding mail checkbox" do
+      it "is hidden if no role_type is selected" do
+        expect(page).to have_selector("#send_onboarding_mail", visible: false)
+      end
+
+      it "is shown when role_type is selected and is checked per default" do
+        choose_role "Präsidium"
+        expect(page).to have_selector("#send_onboarding_mail", visible: true)
+        expect(find("#send_onboarding_mail")).to be_checked
+      end
+
+      it "stays hidden if role_type without onboarding mail option is selected" do
+        choose_role "Leserecht"
+        expect(page).to have_selector("#send_onboarding_mail", visible: false)
+      end
+    end
+  end
+
+  context "edit" do
+    before { visit edit_group_role_path(group_id: group.id, id: role.id) }
+
+    describe "onboarding mail checkbox" do
+      it "is hidden per default" do
+        expect(page).to have_selector("#send_onboarding_mail", visible: false)
+      end
+
+      it "is shown when role_type is selected and is unchecked per default" do
+        choose_role "Präsidium"
+        expect(page).to have_selector("#send_onboarding_mail", visible: true)
+        expect(find("#send_onboarding_mail")).not_to be_checked
+      end
+
+      it "stays hidden if role_type without onboarding mail option is selected" do
+        choose_role "Leserecht"
+        expect(page).to have_selector("#send_onboarding_mail", visible: false)
+      end
+    end
+  end
+end

--- a/spec/mailers/people/sektionsfunktionaere_mailer_spec.rb
+++ b/spec/mailers/people/sektionsfunktionaere_mailer_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe People::SektionsfunktionaereMailer do
+  let(:person) { people(:mitglied) }
+  let(:funktionaere) { groups(:bluemlisalp_funktionaere) }
+  let(:touren_und_kurse) { groups(:bluemlisalp_touren_und_kurse) }
+  let(:huetten_group) {
+    Fabricate(Group::SektionsClubhuette.sti_name,
+      parent: Fabricate(Group::SektionsClubhuetten.sti_name, parent: groups(:bluemlisalp_funktionaere)))
+  }
+
+  before do
+    Group.root.update!(course_admin_email: "course@coursecourse.course")
+  end
+
+  shared_examples "onboarding mail" do |method, bcc|
+    subject(:mail) { described_class.send(method, role) }
+
+    it "sends to person email" do
+      expect(mail.to).to eq([person.email])
+    end
+
+    it "should have bcc #{bcc}" do
+      expect(mail.bcc).to eq([bcc])
+    end
+  end
+
+  describe "#praesidium_onboarding" do
+    let(:role) { Group::SektionsFunktionaere::Praesidium.new(person:, group: funktionaere) }
+
+    it_behaves_like "onboarding mail", :praesidium_onboarding, SacCas::MV_EMAIL
+  end
+
+  describe "#mitgliederverwaltung_onboarding" do
+    let(:role) { Group::SektionsFunktionaere::Mitgliederverwaltung.new(person:, group: funktionaere) }
+
+    it_behaves_like "onboarding mail", :mitgliederverwaltung_onboarding, SacCas::MV_EMAIL
+  end
+
+  describe "#administration_onboarding" do
+    let(:role) { Group::SektionsFunktionaere::Administration.new(person:, group: funktionaere) }
+
+    it_behaves_like "onboarding mail", :administration_onboarding, SacCas::MV_EMAIL
+  end
+
+  describe "#redaktion_onboarding" do
+    let(:role) { Group::SektionsFunktionaere::Redaktion.new(person:, group: funktionaere) }
+
+    it_behaves_like "onboarding mail", :redaktion_onboarding, SacCas::MV_EMAIL
+  end
+
+  describe "#kulturbeauftragter_onboarding" do
+    let(:role) { Group::SektionsFunktionaere::Kulturbeauftragter.new(person:, group: funktionaere) }
+
+    it_behaves_like "onboarding mail", :kulturbeauftragter_onboarding, SacCas::MV_EMAIL
+  end
+
+  describe "#umweltbeauftragter_onboarding" do
+    let(:role) { Group::SektionsFunktionaere::Umweltbeauftragter.new(person:, group: funktionaere) }
+
+    it_behaves_like "onboarding mail", :umweltbeauftragter_onboarding, SacCas::MV_EMAIL
+  end
+
+  describe "#huettenobmann_onboarding" do
+    let(:role) { Group::SektionsFunktionaere::Huettenobmann.new(person:, group: funktionaere) }
+
+    it_behaves_like "onboarding mail", :huettenobmann_onboarding, SacCas::HUETTEN_EMAIL
+  end
+
+  describe "#tourenchef_onboarding" do
+    let(:role) { Group::SektionsTourenUndKurse::Tourenchef.new(person:, group: touren_und_kurse) }
+
+    it_behaves_like "onboarding mail", :tourenchef_onboarding, "course@coursecourse.course"
+  end
+
+  describe "#tourenleiter_onboarding" do
+    let(:role) { Group::SektionsTourenUndKurse::TourenleiterOhneQualifikation.new(person:, group: touren_und_kurse) }
+
+    it_behaves_like "onboarding mail", :tourenleiter_onboarding, "course@coursecourse.course"
+  end
+
+  describe "#kibe_chef_onboarding" do
+    let(:role) { Group::SektionsTourenUndKurse::KibeChef.new(person:, group: touren_und_kurse) }
+
+    it_behaves_like "onboarding mail", :kibe_chef_onboarding, SacCas::JUGEND_EMAIL
+  end
+
+  describe "#fabe_chef_onboarding" do
+    let(:role) { Group::SektionsTourenUndKurse::FabeChef.new(person:, group: touren_und_kurse) }
+
+    it_behaves_like "onboarding mail", :fabe_chef_onboarding, SacCas::JUGEND_EMAIL
+  end
+
+  describe "#jo_chef_onboarding" do
+    let(:role) { Group::SektionsTourenUndKurse::JoChef.new(person:, group: touren_und_kurse) }
+
+    it_behaves_like "onboarding mail", :jo_chef_onboarding, SacCas::JUGEND_EMAIL
+  end
+
+  describe "#huettenchef_onboarding" do
+    let(:role) { Group::SektionsClubhuette::Huettenchef.new(person:, group: huetten_group) }
+
+    it_behaves_like "onboarding mail", :huettenchef_onboarding, SacCas::HUETTEN_EMAIL
+  end
+
+  describe "#huettenwart_onboarding" do
+    let(:role) { Group::SektionsClubhuette::Huettenwart.new(person:, group: huetten_group) }
+
+    it_behaves_like "onboarding mail", :huettenwart_onboarding, SacCas::HUETTEN_EMAIL
+  end
+end

--- a/spec/models/concerns/roles/sektionsfunktionaere_onboarding_mails_spec.rb
+++ b/spec/models/concerns/roles/sektionsfunktionaere_onboarding_mails_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Roles::SektionsfunktionaereOnboardingMails do
+  let(:person) { Fabricate(:person) }
+  let(:group) { groups(:bluemlisalp_funktionaere) }
+  let(:role) { Group::SektionsFunktionaere::Praesidium.new(person:, group:) }
+
+  it "delivers mail when send_onboarding_mail is set to true" do
+    role.send_onboarding_mail = true
+    expect { role.save! }.to have_enqueued_mail(People::SektionsfunktionaereMailer, :praesidium_onboarding)
+  end
+
+  it "does not deliver mail when send_onboarding_mail is false" do
+    role.send_onboarding_mail = false
+    expect { role.save! }.not_to have_enqueued_mail(People::SektionsfunktionaereMailer, :praesidium_onboarding)
+  end
+end


### PR DESCRIPTION
Im Ticket ist kein Betreff für die einzelnen Mails definiert, ich habe mal das Label übernommen.

Specs sind kaputt bis: https://github.com/hitobito/hitobito_sac_cas/issues/2449 gemerged wird