### PR TITLE
Resolve deprecation around 'expect_query_count'

### DIFF
--- a/spec/domain/export/tabular/people/austritte_spec.rb
+++ b/spec/domain/export/tabular/people/austritte_spec.rb
@@ -173,9 +173,9 @@ describe Export::Tabular::People::Austritte do
       tabular = build("1.1.2014-31.12.2014")
 
       travel_to(Time.zone.local(2014, 6, 30)) do
-        expect_query_count do
+        expect do
           expect(tabular.data_rows).to have(5).items
-        end.to eq(5)
+        end.to make(5).db_queries
       end
     end
 

--- a/spec/domain/export/tabular/people/beitragskategorie_wechsel_spec.rb
+++ b/spec/domain/export/tabular/people/beitragskategorie_wechsel_spec.rb
@@ -159,9 +159,9 @@ describe Export::Tabular::People::BeitragskategorieWechsel do
       create_role("adult", person: people(:familienmitglied2), start_on: "1.1.2000", end_on: "31.12.2014")
       tabular = build("1.1.2015-31.12.2015")
 
-      expect_query_count do
+      expect do
         expect(tabular.data_rows).to have(3).items
-      end.to eq(5)
+      end.to make(5).db_queries
     end
 
     describe "common" do

--- a/spec/domain/export/tabular/people/eintritte_spec.rb
+++ b/spec/domain/export/tabular/people/eintritte_spec.rb
@@ -255,9 +255,9 @@ describe Export::Tabular::People::Eintritte do
     it "does not do N+1 queries" do
       tabular = build("1.1.2015-31.12.2015")
 
-      expect_query_count do
+      expect do
         expect(tabular.data_rows).to have(4).items
-      end.to eq 3
+      end.to make(3).db_queries
     end
 
     describe "common" do

--- a/spec/domain/export/tabular/people/jubilare_spec.rb
+++ b/spec/domain/export/tabular/people/jubilare_spec.rb
@@ -17,7 +17,9 @@ describe Export::Tabular::People::Jubilare do
 
   describe "#data_rows" do
     it "does not do N+1 queries" do
-      expect_query_count { tabular.data_rows.to_a }.to eq 7
+      expect do
+        tabular.data_rows.to_a
+      end.to make(7).db_queries
     end
 
     it "contains all attributes" do

--- a/spec/domain/export/tabular/people/sac_mitglieder_spec.rb
+++ b/spec/domain/export/tabular/people/sac_mitglieder_spec.rb
@@ -127,7 +127,7 @@ describe Export::Tabular::People::SacMitglieder do
 
   describe "#data_rows" do
     it "does not do N+1" do
-      # Expected 7 queries:
+      # Expected 8 queries:
       # - 1 for loading the group
       # - 1 for loading the groups children
       # - 1 for loading all people
@@ -136,10 +136,15 @@ describe Export::Tabular::People::SacMitglieder do
       # - 1 for loading the people's roles_unscoped
       # - 1 for loading the people's roles
       # - 1 for loading the people's roles' groups
-      expect_query_count do
+      expect do
         # make sure we have more than one row for the test to be meaningful
         expect(tabular.data_rows.to_a).to have_at_least(2).items
-      end.to eq 8
+      end.to make(8).db_queries.with(
+        "Group Load": 3,
+        "Person Load": 1,
+        "PhoneNumber Load": 2,
+        "Role Load": 2
+      )
     end
   end
 end

--- a/spec/domain/invoices/sac_memberships/extend_roles_for_invoicing_spec.rb
+++ b/spec/domain/invoices/sac_memberships/extend_roles_for_invoicing_spec.rb
@@ -49,8 +49,11 @@ describe Invoices::SacMemberships::ExtendRolesForInvoicing do
     end
 
     it "only makes 5 database queries" do
-      # SELECT in batches (2x) and SELECT for beitragskategorie change (2x) and UPDATE all (1x)
-      expect_query_count { extend_roles }.to eq(5)
+      expect { extend_roles }.to make(5).db_queries.with(
+        SQL: 2, # SELECT in batches
+        "Role Pluck": 2, # SELECT for beitragskategorie change
+        "Role Update All": 1
+      )
     end
 
     context "with multiple batches and various roles" do
@@ -121,7 +124,7 @@ describe Invoices::SacMemberships::ExtendRolesForInvoicing do
     let(:count) { (prolongation_date.year == Time.zone.today.year) ? 3 : 5 }
 
     it "doesnt extend the role" do
-      expect { expect_query_count { extend_roles }.to eq(count) }.not_to change {
+      expect { expect { extend_roles }.to make(count).db_queries }.not_to change {
         person_mitglied_role.reload.end_on
       }
     end

--- a/spec/jobs/people/sac_memberships/destroy_households_for_inactive_memberships_job_spec.rb
+++ b/spec/jobs/people/sac_memberships/destroy_households_for_inactive_memberships_job_spec.rb
@@ -23,7 +23,7 @@ describe People::SacMemberships::DestroyHouseholdsForInactiveMembershipsJob do
     let(:inactive_family_people) { subject.inactive_family_people(sac_family_main_person: true) }
 
     it "makes only 1 query" do
-      expect_query_count { inactive_family_people.to_a }.to eq 1
+      expect { inactive_family_people.to_a }.to make(1).db_queries
     end
 
     context "with ended stammsektion roles" do

--- a/spec/models/event/answer_spec.rb
+++ b/spec/models/event/answer_spec.rb
@@ -25,12 +25,12 @@ describe Event::Answer do
       participation.init_answers
       ids = participation.answers.pluck(:id)
 
-      expect_query_count do
+      expect do
         list = participation.answers.list.to_a
         expect(list.map { |a| a.question.question })
           .to eq(["GA oder Halbtax?", "Ich bin Vegetarier", "Sonst noch was?"])
         expect(list.map(&:id)).to match_array(ids)
-      end.to eq(3)
+      end.to make(3).db_queries
     end
   end
 end


### PR DESCRIPTION
The replacement syntax offers much more detail and descriptiveness.

This is basically a side-product of working a feature.