### PR TITLE
Include canton in all mitgliedschaft-exports (#2468)

### DIFF
--- a/app/domain/export/tabular/people/mitgliedschaft.rb
+++ b/app/domain/export/tabular/people/mitgliedschaft.rb
@@ -32,6 +32,7 @@ module Export::Tabular::People
       :address_care_of,
       :zip_code,
       :town,
+      :canton,
       :country
     ].freeze
 

--- a/app/domain/export/tabular/people/mitgliedschaft_row.rb
+++ b/app/domain/export/tabular/people/mitgliedschaft_row.rb
@@ -67,6 +67,10 @@ module Export::Tabular::People
       entry.phone_number_mobile&.number
     end
 
+    def canton
+      Cantons.full_name(entry.canton)
+    end
+
     private
 
     def roles(*role_classes)

--- a/app/domain/export/tabular/people/mitgliedschaft_row.rb
+++ b/app/domain/export/tabular/people/mitgliedschaft_row.rb
@@ -68,7 +68,7 @@ module Export::Tabular::People
     end
 
     def canton
-      Cantons.full_name(entry.canton)
+      entry.canton_label
     end
 
     private

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -1986,6 +1986,7 @@ de:
       address_care_of: Adresszusatz
       zip_code: PLZ
       town: Ort
+      canton: Kanton
       country: Land
 
   export/tabular/people/jubilare:

--- a/spec/domain/export/tabular/people/austritte_spec.rb
+++ b/spec/domain/export/tabular/people/austritte_spec.rb
@@ -33,7 +33,7 @@ describe Export::Tabular::People::Austritte do
   end
 
   it "has expected attributes" do
-    expect(build.attributes).to eq [
+    attrs = [
       :id,
       :url,
       :sektion,
@@ -63,8 +63,11 @@ describe Export::Tabular::People::Austritte do
       :address_care_of,
       :zip_code,
       :town,
+      :canton,
       :country
     ]
+    expect(build.attributes).to match_array(attrs)
+    expect(build.attributes).to eq(attrs)
   end
 
   it "has range in sheet name" do
@@ -224,7 +227,8 @@ describe Export::Tabular::People::Austritte do
           address_care_of: "c/o Mami u Papi",
           postbox: "Postfach 1",
           gender: "m",
-          birthday: "21.04.1972"
+          birthday: "21.04.1972",
+          canton: "be"
         )
         mitglied.phone_numbers.create!(label: "landline", number: "031 333 44 55")
         mitglied.phone_numbers.create!(label: "mobile", number: "079 333 44 55")
@@ -259,6 +263,7 @@ describe Export::Tabular::People::Austritte do
           address_care_of: "c/o Mami u Papi",
           zip_code: "2843",
           town: "Neu Carlscheid",
+          canton: "Bern",
           country: "CH"
         })
       end

--- a/spec/domain/export/tabular/people/beitragskategorie_wechsel_spec.rb
+++ b/spec/domain/export/tabular/people/beitragskategorie_wechsel_spec.rb
@@ -22,7 +22,7 @@ describe Export::Tabular::People::BeitragskategorieWechsel do
   end
 
   it "has expected attributes" do
-    expect(build.attributes).to eq [
+    attrs = [
       :id,
       :url,
       :sektion,
@@ -56,8 +56,12 @@ describe Export::Tabular::People::BeitragskategorieWechsel do
       :address_care_of,
       :zip_code,
       :town,
+      :canton,
       :country
     ]
+
+    expect(build.attributes).to match_array(attrs)
+    expect(build.attributes).to eq(attrs)
   end
 
   it "has range in sheet name" do
@@ -179,7 +183,8 @@ describe Export::Tabular::People::BeitragskategorieWechsel do
           address_care_of: "c/o Mami u Papi",
           postbox: "Postfach 1",
           gender: "m",
-          birthday: "21.04.1972"
+          birthday: "21.04.1972",
+          canton: "so"
         )
         mitglied.phone_numbers.create!(label: "landline", number: "031 333 44 55")
         mitglied.phone_numbers.create!(label: "mobile", number: "079 333 44 55")
@@ -215,6 +220,7 @@ describe Export::Tabular::People::BeitragskategorieWechsel do
           address_care_of: "c/o Mami u Papi",
           zip_code: "2843",
           town: "Neu Carlscheid",
+          canton: "Solothurn",
           country: "CH"
         })
       end

--- a/spec/domain/export/tabular/people/eintritte_spec.rb
+++ b/spec/domain/export/tabular/people/eintritte_spec.rb
@@ -22,7 +22,7 @@ describe Export::Tabular::People::Eintritte do
   end
 
   it "has expected attributes" do
-    expect(build.attributes).to eq [
+    attrs = [
       :id,
       :url,
       :sektion,
@@ -53,12 +53,15 @@ describe Export::Tabular::People::Eintritte do
       :address_care_of,
       :zip_code,
       :town,
+      :canton,
       :country
     ]
+    expect(build.attributes).to match_array(attrs)
+    expect(build.attributes).to eq attrs
   end
 
   it "has expected labels" do
-    expect(build.labels).to eq [
+    labels = [
       "Mitgliedernummer",
       "Mitgliedschaften",
       "Sektion",
@@ -89,8 +92,11 @@ describe Export::Tabular::People::Eintritte do
       "Adresszusatz",
       "PLZ",
       "Ort",
+      "Kanton",
       "Land"
     ]
+    expect(build.labels).to match_array(labels)
+    expect(build.labels).to eq(labels)
   end
 
   it "has range in sheet name" do
@@ -269,7 +275,8 @@ describe Export::Tabular::People::Eintritte do
           address_care_of: "c/o Mami u Papi",
           postbox: "Postfach 1",
           gender: "m",
-          birthday: "21.04.1972"
+          birthday: "21.04.1972",
+          canton: "be"
         )
 
         mitglied.phone_numbers.create!(label: "landline", number: "031 333 44 55")
@@ -307,6 +314,7 @@ describe Export::Tabular::People::Eintritte do
           address_care_of: "c/o Mami u Papi",
           zip_code: "2843",
           town: "Neu Carlscheid",
+          canton: "Bern",
           country: "CH"
         })
       end

--- a/spec/domain/export/tabular/people/jubilare_spec.rb
+++ b/spec/domain/export/tabular/people/jubilare_spec.rb
@@ -27,7 +27,8 @@ describe Export::Tabular::People::Jubilare do
         address_care_of: "c/o Mami u Papi",
         postbox: "Postfach 1",
         gender: "m",
-        birthday: "21.04.1972"
+        birthday: "21.04.1972",
+        canton: "be"
       )
       people(:mitglied).phone_numbers.create!(label: "landline", number: "031 333 44 55")
       people(:mitglied).phone_numbers.create!(label: "mobile", number: "079 333 44 55")
@@ -73,6 +74,7 @@ describe Export::Tabular::People::Jubilare do
         "c/o Mami u Papi",
         "2843",
         "Neu Carlscheid",
+        "Bern",
         "CH"
       ])
 
@@ -102,6 +104,7 @@ describe Export::Tabular::People::Jubilare do
         nil,
         "2843",
         "Neu Carlscheid",
+        nil,
         nil
       ])
     end

--- a/spec/domain/export/tabular/people/jubilare_spec.rb
+++ b/spec/domain/export/tabular/people/jubilare_spec.rb
@@ -104,7 +104,7 @@ describe Export::Tabular::People::Jubilare do
         nil,
         "2843",
         "Neu Carlscheid",
-        nil,
+        "",
         nil
       ])
     end


### PR DESCRIPTION
This builds upon #2449, so for review ease, I set the merge-base to be that. In the end, this of course needs to go into master.

In terms of implementation, I added the canton-column to the BeitragskategorieWechsel as well. This was not intended, but a side-effect of adding to a rather central place. Looking at the columns in that export, it does not seems wrong to also include the canton there.

If that is not wanted, this could be adjusted to match the Issue-description more closely.