### PR TITLE
Include canton in post address sync (#2434)

### DIFF
--- a/app/models/sac_cas/person.rb
+++ b/app/models/sac_cas/person.rb
@@ -28,6 +28,8 @@ module SacCas::Person
 
     Person.used_attributes.delete(:nickname)
 
+    self.address_sync_relevant_fields += [:canton]
+
     delegate :active?, :active_in?, :anytime?, :family?, :stammsektion_role, :terminated?,
       to: :sac_membership, prefix: true
     delegate :family_id, to: :sac_membership

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -2529,6 +2529,10 @@ de:
       index:
         my_subscriptions: Meine Abos
         available_subscriptions: Verfügbare Abos
+    tags:
+      tag:
+        category_validation:
+          post_address_check_invalid: SAC_Post_Adressenabgleich_fehlerhaft
 
   public_events:
     show:

--- a/db/migrate/20260616132345_rename_address_sync_tags.rb
+++ b/db/migrate/20260616132345_rename_address_sync_tags.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class RenameAddressSyncTags < ActiveRecord::Migration[8.0]
+  def up
+    ActsAsTaggableOn::Tag.find_or_create_by!(name: "Adressabgleich inaktiv").update!(name: "SAC_Post_Adressenabgleich_inaktiv")
+  end
+end

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -198,6 +198,9 @@ module HitobitoSacCas
         Ort: :town
       }
       Synchronize::Addresses::SwissPost::ResultProcessor.remote_identifier = "KDNR"
+      Synchronize::Addresses::SwissPost::ResultProcessor.qstat_tag_prefix =
+        "SAC_Post_Adressenabgleich_QSTAT"
+      Synchronize::Addresses::SwissPost::ResultProcessor.fields[:canton] = "Canton"
 
       ## Resources
       GroupResource.include SacCas::GroupResource


### PR DESCRIPTION
> [!IMPORTANT] 
If this is released, the `config/post-address-sync.yml` excluded_tags has to be adjusted to:
`SAC_Post_Adressenabgleich_inaktiv` and `category_validation:post_address_check_invalid`
To be safe I would suggest to just add these on merge already :upside_down_face: and remove the obsolete tags after release :upside_down_face: 