### PR TITLE
Remove applied participation state for tours (#2556)

### DIFF
--- a/app/controllers/sac_cas/event/participations/send_mails_controller.rb
+++ b/app/controllers/sac_cas/event/participations/send_mails_controller.rb
@@ -76,10 +76,6 @@ module SacCas::Event::Participations::SendMailsController
 
   # Tour participation mails
 
-  def dispatch_event_tour_application_confirmation_applied_mail
-    Event::TourParticipationMailer.confirmation(participation, mail_type).deliver_later
-  end
-
   def dispatch_event_tour_application_confirmation_unconfirmed_mail
     Event::TourParticipationMailer.confirmation(participation, mail_type).deliver_later
   end

--- a/app/controllers/sac_cas/event/participations_controller.rb
+++ b/app/controllers/sac_cas/event/participations_controller.rb
@@ -44,7 +44,7 @@ module SacCas::Event::ParticipationsController # rubocop:disable Metrics/ModuleL
     entry.update!(
       cancel_statement: nil,
       canceled_at: nil,
-      state: event.maximum_participants_reached? ? :applied : :assigned
+      state: event.maximum_participants_reached? ? :unconfirmed : :assigned
     )
 
     refresh_participant_counts

--- a/app/domain/sac_cas/event/participant_assigner.rb
+++ b/app/domain/sac_cas/event/participant_assigner.rb
@@ -1,0 +1,12 @@
+#  Copyright (c) 2026, Schweizer Alpenclub SAC. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module SacCas::Event::ParticipantAssigner
+  extend ActiveSupport::Concern
+
+  def set_active(active)
+    participation.update!(active: active, state: active ? "assigned" : "unconfirmed")
+  end
+end

--- a/app/helpers/sac_cas/event/participation_buttons.rb
+++ b/app/helpers/sac_cas/event/participation_buttons.rb
@@ -15,7 +15,7 @@ module SacCas::Event::ParticipationButtons
       summon: [:assigned, if: -> { @event.state == "ready" }],
       absent: [:assigned, :summoned, :attended],
       attend: [:absent, if: -> { @event.closed? }],
-      assign: [:applied, :absent, if: -> { !@event.closed? }]
+      assign: [:unconfirmed, :applied, :absent, if: -> { !@event.closed? }]
     }
   end
 
@@ -54,8 +54,7 @@ module SacCas::Event::ParticipationButtons
   end
 
   def her_own?
-    # rubocop:todo Layout/LineLength
-    @template.current_user.id == @participation.participant_id && @participation.participant_type == Person.sti_name
-    # rubocop:enable Layout/LineLength
+    @template.current_user.id == @participation.participant_id &&
+      @participation.participant_type == Person.sti_name
   end
 end

--- a/app/jobs/sac_cas/event/participation_confirmation_job.rb
+++ b/app/jobs/sac_cas/event/participation_confirmation_job.rb
@@ -46,10 +46,8 @@ module SacCas::Event::ParticipationConfirmationJob
   def tour_confirmation_content_key
     if participation.state == "assigned"
       Event::TourParticipationMailer::ASSIGNED
-    elsif participation.state == "unconfirmed"
-      Event::TourParticipationMailer::UNCONFIRMED
     else
-      Event::TourParticipationMailer::APPLIED
+      Event::TourParticipationMailer::UNCONFIRMED
     end
   end
 end

--- a/app/mailers/event/tour_participation_mailer.rb
+++ b/app/mailers/event/tour_participation_mailer.rb
@@ -8,7 +8,6 @@
 class Event::TourParticipationMailer < ApplicationMailer
   include TourMailer
 
-  APPLIED = "event_tour_application_confirmation_applied"
   CLOSING = "event_tour_closing"
   UNCONFIRMED = "event_tour_application_confirmation_unconfirmed"
   ASSIGNED = "event_tour_application_confirmation_assigned"

--- a/app/models/event/tour.rb
+++ b/app/models/event/tour.rb
@@ -10,7 +10,6 @@ class Event::Tour < Event
   include I18nEnums
 
   self.manually_sendable_participant_mails = [
-    Event::TourParticipationMailer::APPLIED,
     Event::TourParticipationMailer::UNCONFIRMED,
     Event::TourParticipationMailer::ASSIGNED,
     Event::TourParticipationMailer::REJECT_PARTICIPATION,
@@ -56,11 +55,11 @@ class Event::Tour < Event
   self.supports_applications = true
   self.supports_invitations = false
 
-  self.possible_participation_states = %w[unconfirmed applied rejected assigned
+  self.possible_participation_states = %w[unconfirmed rejected assigned
     attended absent canceled annulled]
   self.active_participation_states = %w[assigned attended]
   self.revoked_participation_states = %w[rejected canceled absent annulled]
-  self.countable_participation_states = %w[unconfirmed applied assigned attended absent]
+  self.countable_participation_states = %w[unconfirmed assigned attended absent]
 
   # Used for Event::TourResource
   attr_accessor :leaders
@@ -153,10 +152,8 @@ class Event::Tour < Event
   def default_participation_state(participation, for_someone_else = false)
     if participation.application.blank? || for_someone_else
       "assigned"
-    elsif places_available? && !automatic_assignment?
-      "unconfirmed"
     else
-      "applied"
+      "unconfirmed"
     end
   end
 

--- a/db/seeds/sac_section_custom_contents.yml
+++ b/db/seeds/sac_section_custom_contents.yml
@@ -547,52 +547,6 @@ event_tour_application_confirmation_unconfirmed:
     Bergsportliche Grüsse,
     {section-name}
 
-event_tour_application_confirmation_applied:
-  label: "Tour: E-Mail Unbestätigte Warteliste"
-  subject: "Auf Warteliste zur Tour {event-name}"
-  placeholders_optional:
-    "recipient-id, recipient-first-name, recipient-last-name, recipient-link,
-    participation-link, participation-additional-information, participation-answers,
-    event-name, event-id, event-link, event-dates, event-essentials, event-requirements, event-details,
-    contact-id, contact-first-name, contact-last-name, contact-email, contact-phone, section-name"
-  body: |
-    Hallo {recipient-first-name} {recipient-last-name} ({recipient-id})
-
-    Vielen Dank für deine Anmeldung für die Tour "{event-name} ({event-id})":
-    {event-link}
-
-    Aktuell sind alle Plätze belegt, weshalb wir dich auf die Warteliste genommen haben.
-    Deine Anmeldung wird in den kommenden Tagen/Wochen bearbeitet. Du erhältst nochmals eine E-Mail von uns mit der definitiven Zusage oder Absage.
-
-    Nachfolgend findest du wichtigsten Eckdaten zur Tour.
-
-    {event-dates}
-
-    {event-essentials}
-
-    {event-requirements}
-
-    {event-details}
-
-    Nachfolgend findest du wichtigsten Angaben aus deiner Anmeldung.
-
-    {participation-answers}
-
-    {participation-additional-information}
-
-    Falls deine Anmeldeangaben nicht mehr aktuell sind, kannst du diese unter folgendem Link bearbeiten:
-    {participation-link}
-
-    Bei Fragen kannst du dich jederzeit an {contact-first-name} {contact-last-name} wenden ({contact-id}, {contact-phone}, {contact-email}).
-
-    Schon gewusst? Du kannst deine SAC Ausbildungs- und Weiterbildungshistorie sowie deine Tourenhistorie unter folgendem Link einsehen:
-    {recipient-link}
-
-    Wir freuen uns auf deine Anmeldung.
-
-    Bergsportliche Grüsse,
-    {section-name}
-
 event_tour_participation_summon:
   label: "Tour: E-Mail Aufgebot"
   subject: "Aufgebot zur Tour {event-name}"

--- a/lib/hitobito_sac_cas/wagon.rb
+++ b/lib/hitobito_sac_cas/wagon.rb
@@ -171,6 +171,7 @@ module HitobitoSacCas
       OidcClaimSetup.prepend SacCas::OidcClaimSetup
       SearchStrategies::SqlConditionBuilder.matchers["people.birthday"] =
         SearchStrategies::SqlConditionBuilder::BirthdayMatcher
+      Event::ParticipantAssigner.prepend SacCas::Event::ParticipantAssigner
       Event::Qualifier::StartAtCalculator.prepend SacCas::Event::Qualifier::StartAtCalculator
       Event::TrainingDays::CoursesLoader.prepend SacCas::Event::TrainingDays::CoursesLoader
       SearchStrategies::PersonSearch.prepend SacCas::SearchStrategies::PersonSearch

--- a/spec/controllers/event/participations/send_mails_controller_spec.rb
+++ b/spec/controllers/event/participations/send_mails_controller_spec.rb
@@ -110,10 +110,6 @@ describe Event::Participations::SendMailsController do
       let(:event) { events(:section_tour) }
 
       it_behaves_like "dispatches mail",
-        :event_tour_application_confirmation_applied,
-        Event::TourParticipationMailer,
-        :confirmation, :participation, "event_tour_application_confirmation_applied"
-      it_behaves_like "dispatches mail",
         :event_tour_application_confirmation_unconfirmed,
         Event::TourParticipationMailer,
         :confirmation, :participation, "event_tour_application_confirmation_unconfirmed"

--- a/spec/controllers/event/participations_controller_spec.rb
+++ b/spec/controllers/event/participations_controller_spec.rb
@@ -665,10 +665,10 @@ describe Event::ParticipationsController do
             canceled_at: Date.current)
         }
 
-        it "PUT#reactivate sets participation to applied when maximum participants is reached" do
+        it "PUT#reactivate sets participation to unconfirmed when maximum participants is reached" do
           allow_any_instance_of(Event).to receive(:maximum_participants_reached?).and_return(true)
           put :reactivate, params: params
-          expect(participation.reload.state).to eq "applied"
+          expect(participation.reload.state).to eq "unconfirmed"
           expect(participation.reload.cancel_statement).to be_nil
           expect(participation.reload.canceled_at).to be_nil
         end

--- a/spec/helpers/sac_cas/event/participation_buttons_spec.rb
+++ b/spec/helpers/sac_cas/event/participation_buttons_spec.rb
@@ -92,7 +92,7 @@ describe Event::ParticipationButtons do
   end
 
   describe "Zugeteilt" do
-    it_behaves_like "conditional action", "Zugeteilt", states: %w[applied absent]
+    it_behaves_like "conditional action", "Zugeteilt", states: %w[unconfirmed applied absent]
     it_behaves_like "conditional action", "Zugeteilt", states: %w[] do
       before { event.state = "closed" }
     end

--- a/spec/jobs/event/participation_confirmation_job_spec.rb
+++ b/spec/jobs/event/participation_confirmation_job_spec.rb
@@ -96,26 +96,18 @@ describe Event::ParticipationConfirmationJob do
       expect(Event::ParticipationMailer).not_to receive(:confirmation)
     end
 
-    it "sends course specific unconfirmed email" do
+    it "sends tour specific unconfirmed email" do
       expect { subject.perform }
         .to have_enqueued_mail(Event::TourParticipationMailer, :confirmation)
         .with(participation, "event_tour_application_confirmation_unconfirmed")
         .and not_change { ActionMailer::Base.deliveries.size }
     end
 
-    it "sends course specific assigned email" do
+    it "sends tour specific assigned email" do
       participation.update!(state: :assigned)
       expect { subject.perform }
         .to have_enqueued_mail(Event::TourParticipationMailer, :confirmation)
         .with(participation, "event_tour_application_confirmation_assigned")
-        .and not_change { ActionMailer::Base.deliveries.size }
-    end
-
-    it "sends course specific applied email" do
-      participation.update!(state: :applied)
-      expect { subject.perform }
-        .to have_enqueued_mail(Event::TourParticipationMailer, :confirmation)
-        .with(participation, "event_tour_application_confirmation_applied")
         .and not_change { ActionMailer::Base.deliveries.size }
     end
   end

--- a/spec/mailers/event/tour_participation_mailer_spec.rb
+++ b/spec/mailers/event/tour_participation_mailer_spec.rb
@@ -18,19 +18,17 @@ describe Event::TourParticipationMailer do
     CustomContent.init_section_specific_contents(section)
   end
 
-  context "applied" do
-    let(:mail) { described_class.confirmation(participation, described_class::APPLIED) }
+  context "unconfirmed" do
+    let(:mail) { described_class.confirmation(participation, described_class::UNCONFIRMED) }
 
     it "sends email to participant" do
-      event.update!(application_opening_at: nil, application_closing_at: nil)
-
       expect(mail.to).to match_array(["e.hillary@hitobito.example.com"])
-      expect(mail.subject).to eq("Auf Warteliste zur Tour Bundstock")
+      expect(mail.subject).to eq("Anmeldung zur Tour Bundstock (unbestätigt)")
       expect(mail.body.to_s).to include(
         "Hallo Edmund Hillary (#{person.id})",
-        "Aktuell sind alle Plätze belegt, weshalb wir dich auf die Warteliste genommen haben.",
+        "Es handelt sich hierbei um keine definitive Zusage.",
         "Bei Fragen kannst du dich jederzeit an " \
-          "#{admin.first_name} #{admin.last_name} wenden (#{admin.id}, , #{admin.email}).",
+  "#{admin.first_name} #{admin.last_name} wenden (#{admin.id}, , #{admin.email}).",
         "Bergsportliche Grüsse,<br>SAC Blüemlisalp",
         "<dt>Kommentar</dt><dd>(keine)</dd>"
       )
@@ -72,19 +70,6 @@ describe Event::TourParticipationMailer do
 
       expect(mail.body.to_s).not_to include(
         "Zusatzinfo"
-      )
-    end
-  end
-
-  context "unconfirmed" do
-    let(:mail) { described_class.confirmation(participation, described_class::UNCONFIRMED) }
-
-    it "sends email to participant" do
-      expect(mail.to).to match_array(["e.hillary@hitobito.example.com"])
-      expect(mail.subject).to eq("Anmeldung zur Tour Bundstock (unbestätigt)")
-      expect(mail.body.to_s).to include(
-        "Hallo Edmund Hillary (#{person.id})",
-        "Es handelt sich hierbei um keine definitive Zusage."
       )
     end
   end

--- a/spec/models/custom_content_spec.rb
+++ b/spec/models/custom_content_spec.rb
@@ -158,7 +158,7 @@ describe SacCas::CustomContent do
       )
 
       expect { CustomContent.init_section_specific_contents(group) }
-        .to change { group.custom_contents.count }.by(24)
+        .to change { group.custom_contents.count }.by(23)
 
       # updated values
       expect(existing.reload.label).to eq("Tour: E-Mail Publikation")

--- a/spec/models/event/tour_spec.rb
+++ b/spec/models/event/tour_spec.rb
@@ -327,13 +327,6 @@ describe Event::Tour do
           .to change { participant.reload.state }.to(eq("rejected"))
       end
 
-      it "updates participation state from applied to rejected" do
-        participant.update!(state: :applied)
-
-        expect { tour.update!(state: :ready) }
-          .to change { participant.reload.state }.to(eq("rejected"))
-      end
-
       it "does not update participation state to previous state if not assigned, unconfirmed or applied" do
         participant.update_column(:state, :summoned)
 
@@ -824,10 +817,10 @@ describe Event::Tour do
         expect(state).to eq "unconfirmed"
       end
 
-      it "returns applied if course has no places available" do
+      it "returns unconfirmed if course has no places available" do
         tour.maximum_participants = 2
         tour.participant_count = 2
-        expect(state).to eq "applied"
+        expect(state).to eq "unconfirmed"
       end
 
       it "returns assigned for participation without application (=leader)" do
@@ -839,13 +832,13 @@ describe Event::Tour do
     context "with automatic_assignment" do
       before { tour.automatic_assignment = true }
 
-      it "returns applied if places are available" do
-        expect(state).to eq "applied"
+      it "returns unconfirmed if places are available" do
+        expect(state).to eq "unconfirmed"
       end
 
-      it "returns applied if course has no places available" do
+      it "returns unconfirmed if course has no places available" do
         tour.participant_count = 2
-        expect(state).to eq "applied"
+        expect(state).to eq "unconfirmed"
       end
     end
   end


### PR DESCRIPTION
Da noch keine produktiven Daten vorhanden sind, wird keine Datenmigration vorgenommen.