### PR TITLE
Allow for staggered membership extension (#2576)

### DIFF
--- a/app/domain/invoices/sac_memberships/membership_manager.rb
+++ b/app/domain/invoices/sac_memberships/membership_manager.rb
@@ -6,6 +6,7 @@
 #  https://github.com/hitobito/hitobito_sac_cas
 
 # Creates/extends sac memberships after membership invoice has been paid.
+# rubocop:disable Metrics/ClassLength
 class Invoices::SacMemberships::MembershipManager
   attr_reader :person, :group, :year, :member, :today, :end_of_year
 
@@ -40,9 +41,62 @@ class Invoices::SacMemberships::MembershipManager
   private
 
   def extend_membership_duration
+    if person.sac_family_main_person?
+      extend_main_person_roles
+      extend_paid_family_member_zusatzsektion_roles
+    elsif non_main_family_member?
+      extend_non_main_family_member_roles
+    else
+      extend_main_person_roles
+    end
+  end
+
+  def non_main_family_member?
+    membership = People::SacMembership.new(
+      person,
+      date: reference_date(person.sac_membership.stammsektion_role)
+    )
+
+    membership.family? && !person.sac_family_main_person?
+  end
+
+  def extend_non_main_family_member_roles
+    capped_end_on = [
+      end_of_year,
+      person.sac_membership.stammsektion_role.end_on
+    ].compact.min
+
+    extend_non_family_roles(person, capped_end_on)
+  end
+
+  def extend_paid_family_member_zusatzsektion_roles
+    person.household_people
+      .reject { |family_member| family_member == person }
+      .reject { |family_member| !paid_membership_invoice?(family_member) }
+      .each do |family_member|
+        extend_non_family_roles(family_member, end_of_year)
+      end
+  end
+
+  def extend_main_person_roles
     relevant_roles_for(person.sac_membership.stammsektion_role).each do |role|
       role.update!(end_on: [end_of_year, role.end_on].compact.max)
     end
+  end
+
+  def extend_non_family_roles(member, new_end)
+    member.sac_membership.zusatzsektion_roles
+      .reject(&:terminated?)
+      .reject { |r| r.beitragskategorie.family? }
+      .each do |role|
+        role.update!(end_on: [new_end, role.end_on].compact.max)
+      end
+  end
+
+  def paid_membership_invoice?(person)
+    ExternalInvoice::SacMembership.payed
+      .where(person: person, year: year)
+      .exists?
   end
 
   def create_new_membership_roles
@@ -261,3 +315,4 @@ class Invoices::SacMemberships::MembershipManager
     )
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/domain/invoices/sac_memberships/membership_manager.rb
+++ b/app/domain/invoices/sac_memberships/membership_manager.rb
@@ -41,7 +41,7 @@ class Invoices::SacMemberships::MembershipManager
   private
 
   def extend_membership_duration
-    if person.sac_family_main_person?
+    if family_main_person?
       extend_main_person_roles
       extend_paid_family_member_zusatzsektion_roles
     elsif non_main_family_member?

--- a/app/domain/invoices/sac_memberships/membership_manager.rb
+++ b/app/domain/invoices/sac_memberships/membership_manager.rb
@@ -72,7 +72,7 @@ class Invoices::SacMemberships::MembershipManager
   def extend_paid_family_member_zusatzsektion_roles
     person.household_people
       .reject { |family_member| family_member == person }
-      .reject { |family_member| !paid_membership_invoice?(family_member) }
+      .select { |family_member| paid_membership_invoice?(family_member) }
       .each do |family_member|
         extend_non_family_roles(family_member, end_of_year)
       end

--- a/app/domain/invoices/sac_memberships/membership_manager.rb
+++ b/app/domain/invoices/sac_memberships/membership_manager.rb
@@ -42,12 +42,12 @@ class Invoices::SacMemberships::MembershipManager
 
   def extend_membership_duration
     if family_main_person?
-      extend_main_person_roles
+      extend_stammsektion_derived_roles
       extend_paid_family_member_zusatzsektion_roles
     elsif non_main_family_member?
       extend_non_main_family_member_roles
     else
-      extend_main_person_roles
+      extend_stammsektion_derived_roles
     end
   end
 
@@ -78,7 +78,7 @@ class Invoices::SacMemberships::MembershipManager
       end
   end
 
-  def extend_main_person_roles
+  def extend_stammsektion_derived_roles
     relevant_roles_for(person.sac_membership.stammsektion_role).each do |role|
       role.update!(end_on: [end_of_year, role.end_on].compact.max)
     end

--- a/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
+++ b/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
@@ -152,7 +152,129 @@ describe Invoices::SacMemberships::MembershipManager do
 
       it "only updates own roles when no family main person" do
         allow(familienmitglied_person).to receive(:sac_family_main_person?).and_return(false)
-        expect(updated_roles_count).to eq(5)
+        # Non-main person with only family-type roles has no non-family zusatzsektion
+        # to extend, so no roles are updated (main person handles family role extension)
+        expect(updated_roles_count).to eq(0)
+      end
+
+      context "family member with einzel zusatzsektion pays before stammsektion" do
+        before do
+          # Give familienmitglied2 an individual (adult) zusatzsektion instead of family.
+          # Use update_all to bypass attr_readonly on beitragskategorie.
+          Group::SektionsMitglieder::MitgliedZusatzsektion
+            .where(id: familienmitglied2_zweitsektion.id)
+            .update_all(beitragskategorie: "adult")
+          familienmitglied2_zweitsektion.reload
+        end
+
+        context "non-main family member pays invoice first" do
+          subject { described_class.new(familienmitglied2_person, bluemlisalp, next_year) }
+
+          it "caps zusatzsektion (Einzel) at stammsektion end_on, does not extend to end_of_year" do
+            subject.update_membership_status
+            familienmitglied2_person.reload
+
+            einzel_role = familienmitglied2_person.sac_membership.zusatzsektion_roles.first
+            expect(einzel_role.end_on).to eq prolongation_date
+            expect(einzel_role.end_on).not_to eq end_of_next_year
+          end
+
+          it "does not extend stammsektion (Familie) role" do
+            subject.update_membership_status
+            familienmitglied2_person.reload
+
+            expect(familienmitglied2_person.sac_membership.stammsektion_role.end_on)
+              .to eq prolongation_date
+          end
+
+          it "does not extend prolongable roles (capped at stammsektion end_on)" do
+            subject.update_membership_status
+            familienmitglied2_person.reload
+
+            familienmitglied2_person.sac_membership.membership_prolongable_roles.each do |role|
+              expect(role.end_on).to eq prolongation_date
+            end
+          end
+        end
+
+        context "main person pays stammsektion after family member already paid" do
+          subject { described_class.new(familienmitglied_person, bluemlisalp, next_year) }
+
+          before do
+            # Create paid external invoice for the family member
+            Fabricate(:sac_membership_invoice,
+              person: familienmitglied2_person,
+              link: bluemlisalp,
+              year: next_year,
+              state: :payed,
+              total: 100)
+
+            # Simulate zusatzsektion was capped at stammsektion end_on
+            familienmitglied2_zweitsektion.update!(end_on: prolongation_date)
+          end
+
+          it "extends family member's zusatzsektion (Einzel) to end_of_year" do
+            subject.update_membership_status
+            familienmitglied2_person.reload
+
+            einzel_role = familienmitglied2_person.sac_membership.zusatzsektion_roles.first
+            expect(einzel_role.end_on).to eq end_of_next_year
+          end
+        end
+
+        context "multiple family members with einzel, some paid some not" do
+          subject { described_class.new(familienmitglied_person, bluemlisalp, next_year) }
+
+          before do
+            # familienmitglied2 has paid Einzel (from outer before)
+            Fabricate(:sac_membership_invoice,
+              person: familienmitglied2_person,
+              link: bluemlisalp,
+              year: next_year,
+              state: :payed,
+              total: 100)
+            familienmitglied2_zweitsektion.update!(end_on: prolongation_date)
+
+            # familienmitglied_kind has Einzel but no paid invoice
+            # Use update_all to bypass attr_readonly on beitragskategorie
+            Group::SektionsMitglieder::MitgliedZusatzsektion
+              .where(id: familienmitglied_kind_zweitsektion.id)
+              .update_all(beitragskategorie: "adult", end_on: prolongation_date)
+            familienmitglied_kind_zweitsektion.reload
+          end
+
+          it "extends paid family member's zusatzsektion to end_of_year" do
+            subject.update_membership_status
+
+            expect(familienmitglied2_person.reload.sac_membership
+              .zusatzsektion_roles.first.end_on).to eq end_of_next_year
+          end
+
+          it "does not extend unpaid family member's zusatzsektion" do
+            subject.update_membership_status
+
+            expect(familienmitglied_kind_person.reload.sac_membership
+              .zusatzsektion_roles.first.end_on).to eq prolongation_date
+          end
+        end
+
+        context "family member pays after stammsektion already renewed" do
+          subject { described_class.new(familienmitglied2_person, bluemlisalp, next_year) }
+
+          before do
+            # Simulate stammsektion was already renewed
+            familienmitglied2.update!(end_on: end_of_next_year)
+            familienmitglied2_person.reload
+          end
+
+          it "extends zusatzsektion (Einzel) normally to end_of_year" do
+            subject.update_membership_status
+            familienmitglied2_person.reload
+
+            einzel_role = familienmitglied2_person.sac_membership.zusatzsektion_roles.first
+            expect(einzel_role.end_on).to eq end_of_next_year
+          end
+        end
       end
 
       context "running in the previous role period (household still exists)" do

--- a/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
+++ b/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
@@ -156,6 +156,13 @@ describe Invoices::SacMemberships::MembershipManager do
       end
 
       context "family member with einzel zusatzsektion pays before stammsektion" do
+        let(:familienmitglied2_ehrenmitglied) do
+          ehrenmitglieder_group.roles.find_by(person: familienmitglied2_person)
+        end
+        let(:familienmitglied_kind_ehrenmitglied) do
+          ehrenmitglieder_group.roles.find_by(person: familienmitglied_kind_person)
+        end
+
         before do
           Group::SektionsMitglieder::MitgliedZusatzsektion
             .where(id: familienmitglied2_zweitsektion.id)
@@ -166,28 +173,13 @@ describe Invoices::SacMemberships::MembershipManager do
         context "non-main family member pays invoice first" do
           subject { described_class.new(familienmitglied2_person, bluemlisalp, next_year) }
 
-          it "caps zusatzsektion (Einzel) at stammsektion end_on, does not extend to end_of_year" do
-            subject.update_membership_status
-            familienmitglied2_person.reload
-
-            expect(familienmitglied2_zweitsektion.end_on).to eq prolongation_date
-            expect(familienmitglied2_zweitsektion.end_on).not_to eq end_of_next_year
-          end
-
-          it "does not extend stammsektion (Familie) role" do
+          it "caps all relevant roles at stammsektion end_on, does not extend to end_of_year" do
             subject.update_membership_status
             familienmitglied2_person.reload
 
             expect(familienmitglied2.end_on).to eq prolongation_date
-          end
-
-          it "does not extend prolongable roles (capped at stammsektion end_on)" do
-            subject.update_membership_status
-            familienmitglied2_person.reload
-
-            familienmitglied2_person.sac_membership.membership_prolongable_roles.each do |role|
-              expect(role.end_on).to eq prolongation_date
-            end
+            expect(familienmitglied2_zweitsektion.end_on).to eq prolongation_date
+            expect(familienmitglied2_ehrenmitglied.end_on).not_to eq end_of_next_year
           end
         end
 
@@ -195,7 +187,6 @@ describe Invoices::SacMemberships::MembershipManager do
           subject { described_class.new(familienmitglied_person, bluemlisalp, next_year) }
 
           before do
-            # Create paid external invoice for the family member
             Fabricate(:sac_membership_invoice,
               person: familienmitglied2_person,
               link: bluemlisalp,
@@ -203,16 +194,16 @@ describe Invoices::SacMemberships::MembershipManager do
               state: :payed,
               total: 100)
 
-            # Simulate zusatzsektion was capped at stammsektion end_on
             familienmitglied2_zweitsektion.update!(end_on: prolongation_date)
           end
 
-          it "extends family member's zusatzsektion (Einzel) to end_of_year" do
+          it "extends familienmitglied2 roles to end_of_year" do
             subject.update_membership_status
             familienmitglied2_person.reload
 
-            einzel_role = familienmitglied2_person.sac_membership.zusatzsektion_roles.first
-            expect(einzel_role.end_on).to eq end_of_next_year
+            expect(familienmitglied2_zweitsektion.reload.end_on).to eq end_of_next_year
+            expect(familienmitglied2.end_on).to eq end_of_next_year
+            expect(familienmitglied2_ehrenmitglied.end_on).to eq end_of_next_year
           end
         end
 
@@ -230,25 +221,31 @@ describe Invoices::SacMemberships::MembershipManager do
             familienmitglied2_zweitsektion.update!(end_on: prolongation_date)
 
             # familienmitglied_kind has Einzel but no paid invoice
-            # Use update_all to bypass attr_readonly on beitragskategorie
             Group::SektionsMitglieder::MitgliedZusatzsektion
               .where(id: familienmitglied_kind_zweitsektion.id)
               .update_all(beitragskategorie: "adult", end_on: prolongation_date)
             familienmitglied_kind_zweitsektion.reload
           end
 
-          it "extends paid family member's zusatzsektion to end_of_year" do
+          it "extends stammsektion and ehremitglied roles" do
             subject.update_membership_status
 
-            expect(familienmitglied2_person.reload.sac_membership
-              .zusatzsektion_roles.first.end_on).to eq end_of_next_year
+            expect(familienmitglied2.end_on).to eq end_of_next_year
+            expect(familienmitglied_kind.end_on).to eq end_of_next_year
+            expect(familienmitglied2_ehrenmitglied.end_on).to eq end_of_next_year
+            expect(familienmitglied_kind_ehrenmitglied.end_on).to eq end_of_next_year
           end
 
-          it "does not extend unpaid family member's zusatzsektion" do
+          it "extends paid familienmitglied2 zusatzsektion to end_of_year" do
             subject.update_membership_status
 
-            expect(familienmitglied_kind_person.reload.sac_membership
-              .zusatzsektion_roles.first.end_on).to eq prolongation_date
+            expect(familienmitglied2_zweitsektion.reload.end_on).to eq end_of_next_year
+          end
+
+          it "does not extend unpaid familienmitglied_kind zusatzsektion" do
+            subject.update_membership_status
+
+            expect(familienmitglied_kind_zweitsektion.reload.end_on).to eq prolongation_date
           end
         end
 
@@ -265,8 +262,7 @@ describe Invoices::SacMemberships::MembershipManager do
             subject.update_membership_status
             familienmitglied2_person.reload
 
-            einzel_role = familienmitglied2_person.sac_membership.zusatzsektion_roles.first
-            expect(einzel_role.end_on).to eq end_of_next_year
+            expect(familienmitglied2_zweitsektion.reload.end_on).to eq end_of_next_year
           end
         end
       end

--- a/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
+++ b/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
@@ -170,17 +170,15 @@ describe Invoices::SacMemberships::MembershipManager do
             subject.update_membership_status
             familienmitglied2_person.reload
 
-            einzel_role = familienmitglied2_person.sac_membership.zusatzsektion_roles.first
-            expect(einzel_role.end_on).to eq prolongation_date
-            expect(einzel_role.end_on).not_to eq end_of_next_year
+            expect(familienmitglied2_zweitsektion.end_on).to eq prolongation_date
+            expect(familienmitglied2_zweitsektion.end_on).not_to eq end_of_next_year
           end
 
           it "does not extend stammsektion (Familie) role" do
             subject.update_membership_status
             familienmitglied2_person.reload
 
-            expect(familienmitglied2_person.sac_membership.stammsektion_role.end_on)
-              .to eq prolongation_date
+            expect(familienmitglied2.end_on).to eq prolongation_date
           end
 
           it "does not extend prolongable roles (capped at stammsektion end_on)" do

--- a/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
+++ b/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
@@ -157,8 +157,6 @@ describe Invoices::SacMemberships::MembershipManager do
 
       context "family member with einzel zusatzsektion pays before stammsektion" do
         before do
-          # Give familienmitglied2 an individual (adult) zusatzsektion instead of family.
-          # Use update_all to bypass attr_readonly on beitragskategorie.
           Group::SektionsMitglieder::MitgliedZusatzsektion
             .where(id: familienmitglied2_zweitsektion.id)
             .update_all(beitragskategorie: "adult")

--- a/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
+++ b/spec/domain/invoices/sac_memberships/membership_manager_spec.rb
@@ -150,10 +150,8 @@ describe Invoices::SacMemberships::MembershipManager do
         expect(updated_roles_count).to eq(14)
       end
 
-      it "only updates own roles when no family main person" do
+      it "has nothing to update for family only roles as not family main person" do
         allow(familienmitglied_person).to receive(:sac_family_main_person?).and_return(false)
-        # Non-main person with only family-type roles has no non-family zusatzsektion
-        # to extend, so no roles are updated (main person handles family role extension)
         expect(updated_roles_count).to eq(0)
       end
 


### PR DESCRIPTION
This has been analyzed and was in part generated with an LLM.

🤖 Add failing specs for staggered family payment order

- non-main family member: zusatzsektion capped at stammsektion end_on
- main person paying later: paid Einzel roles extended to end_of_year
- mixed paid/unpaid family members
- Einzel paid after stammsektion: normal extension
- fix attr_readonly(:beitragskategorie) by using update_all instead of update! — change silently dropped, role stayed 'family' when tests expected 'adult'.
- Add staggered payment scenarios (non-main pays first, main pays later, multiple housemates, stammsektion already renewed).

🤖 Staggered family payment: cap non-main Einzel at stammsektion end_on,
  extend paid housemate roles

- Split extend_membership_duration: main person extends all + paid housemate Einzel; non-main family member only caps their non-family zusatzsektion at stammsektion end_on; others get full extension.
- non_main_family_member? checks family status at reference_date, not today, so child-turned-youth (family roles expired Dec 31, youth roles start Jan 1) gets full extension instead of capped Einzel-only path.
- extend_paid_family_member_zusatzsektion_roles: main person extends previously-paid housemate non-family zusatzsektion roles to end_of_year after stammsektion is renewed.

👨‍💻 Fixes and Refactorings towards readability