### PR TITLE
Restrict external training days to half or full days (#2436)

### DIFF
--- a/app/jobs/migrations/round_external_training_days_to_half_days_job.rb
+++ b/app/jobs/migrations/round_external_training_days_to_half_days_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+module Migrations
+  class RoundExternalTrainingDaysToHalfDaysJob < BaseJob
+    def perform
+      affected_trainings = ExternalTraining.where("(training_days * 2) % 1 <> 0")
+
+      # DISTINCT ON, ordered by finish_at, picks the earliest adjusted training per
+      # person and event_kind (see Memberships::UndoTermination for the same idiom).
+      training_ids_to_reissue_qualifications = affected_trainings
+        .order(:person_id, :event_kind_id, :finish_at)
+        .select("DISTINCT ON (person_id, event_kind_id) *")
+        .to_a
+        .pluck(:id)
+
+      affected_trainings.update_all("training_days = CEIL(training_days * 2) / 2")
+
+      ExternalTraining.where(id: training_ids_to_reissue_qualifications).find_each do |training|
+        ExternalTrainings::Qualifier.new(training.person, training, "participant").issue
+      end
+    end
+  end
+end

--- a/app/models/external_training.rb
+++ b/app/models/external_training.rb
@@ -36,6 +36,7 @@ class ExternalTraining < ActiveRecord::Base
   validates_by_schema
   validates_date :finish_at, on_or_after: :start_at, allow_blank: true
   validates_date :finish_at, on_or_before: lambda { Date.current }
+  validate :assert_training_days_is_half_day_multiple
 
   scope :list, -> { order(finish_at: :desc) }
 
@@ -63,6 +64,12 @@ class ExternalTraining < ActiveRecord::Base
   alias_method :kind, :event_kind
 
   private
+
+  def assert_training_days_is_half_day_multiple
+    return if training_days.nil?
+
+    errors.add(:training_days, :half_or_full_number) unless (training_days * 2) % 1 == 0
+  end
 
   def qualifier
     ExternalTrainings::Qualifier.new(person, self, "participant")

--- a/config/locales/wagon.de.yml
+++ b/config/locales/wagon.de.yml
@@ -810,6 +810,11 @@ de:
           no_base_activity: ist keine Hauptaktivität.
           combination_exists: hat bereits eine entsprechende Zuständigkeit definiert.
 
+        external_training:
+          attributes:
+            training_days:
+              half_or_full_number: muss eine ganze oder halbe Zahl sein
+
         group/sektions_touren_und_kurse/tourenleiter:
           requires_active_qualification: Person muss mindestens eine aktive Qualifikation besitzen.
 

--- a/db/migrate/20260810120000_round_external_training_days_to_half_days.rb
+++ b/db/migrate/20260810120000_round_external_training_days_to_half_days.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+class RoundExternalTrainingDaysToHalfDays < ActiveRecord::Migration[8.0]
+  def up
+    Migrations::RoundExternalTrainingDaysToHalfDaysJob.new.enqueue!
+  end
+end

--- a/spec/jobs/migrations/round_external_training_days_to_half_days_job_spec.rb
+++ b/spec/jobs/migrations/round_external_training_days_to_half_days_job_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Alpen-Club. This file is part of
+#  hitobito_sac_cas and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sac_cas.
+
+require "spec_helper"
+
+describe Migrations::RoundExternalTrainingDaysToHalfDaysJob do
+  let(:job) { described_class.new }
+
+  # Bypasses validation (not callbacks) so the real qualifier runs once with the invalid
+  # value at creation time, like it would have for data entered before this validation existed.
+  def create_invalid_external_training(training_days, finish_at: Time.zone.today,
+    event_kind: event_kinds(:ski_course), person: people(:mitglied))
+    training = Fabricate.build(:external_training, person: person, event_kind: event_kind,
+      start_at: finish_at, finish_at: finish_at, training_days: training_days)
+    training.save!(validate: false)
+    training
+  end
+
+  {
+    0.1 => 0.5,
+    10.2 => 10.5,
+    9.3 => 9.5,
+    3.4 => 3.5,
+    12.6 => 13.0,
+    7.7 => 8.0,
+    9.8 => 10.0,
+    4.9 => 5.0
+  }.each do |training_days, expected|
+    it "rounds up #{training_days} to #{expected}" do
+      training = create_invalid_external_training(training_days)
+      job.perform
+      expect(training.reload.training_days).to eq(expected)
+    end
+  end
+
+  it "does not change training_days that are already a half day multiple" do
+    training = create_invalid_external_training(2.5)
+    expect { job.perform }.not_to change { training.reload.training_days }
+  end
+
+  it "updates multiple affected records" do
+    training1 = create_invalid_external_training(2.2)
+    training2 = create_invalid_external_training(4.7)
+
+    job.perform
+
+    expect(training1.reload.training_days).to eq(2.5)
+    expect(training2.reload.training_days).to eq(5.0)
+  end
+
+  it "does not issue qualifications for unaffected trainings" do
+    create_invalid_external_training(5)
+
+    expect(ExternalTrainings::Qualifier).not_to receive(:new)
+
+    job.perform
+  end
+
+  it "issues qualifications once per person and event_kind, using the earliest adjusted training" do
+    earlier = create_invalid_external_training(4.7, finish_at: Date.new(2023, 6, 1))
+    create_invalid_external_training(2.2, finish_at: Date.new(2024, 6, 1),
+      person: earlier.person, event_kind: earlier.event_kind)
+    create_invalid_external_training(1.1, finish_at: Date.new(2025, 1, 1),
+      person: earlier.person, event_kind: earlier.event_kind)
+
+    qualifier = instance_double(ExternalTrainings::Qualifier, issue: true)
+    expect(ExternalTrainings::Qualifier).to receive(:new)
+      .with(earlier.person, earlier, "participant").once.and_return(qualifier)
+
+    job.perform
+  end
+
+  it "issues qualifications separately per person, each using their own earliest adjusted training" do
+    mitglied_earliest = create_invalid_external_training(4.7, finish_at: Date.new(2023, 6, 1),
+      person: people(:mitglied))
+    create_invalid_external_training(2.2, finish_at: Date.new(2024, 6, 1),
+      person: people(:mitglied), event_kind: mitglied_earliest.event_kind)
+
+    admin_earliest = create_invalid_external_training(1.1, finish_at: Date.new(2022, 3, 1),
+      person: people(:admin))
+    create_invalid_external_training(9.3, finish_at: Date.new(2023, 1, 1),
+      person: people(:admin), event_kind: admin_earliest.event_kind)
+
+    calls = []
+    allow(ExternalTrainings::Qualifier).to receive(:new) do |person, training, role|
+      calls << [person, training, role]
+      instance_double(ExternalTrainings::Qualifier, issue: true)
+    end
+
+    job.perform
+
+    expect(calls).to contain_exactly(
+      [people(:mitglied), mitglied_earliest, "participant"],
+      [people(:admin), admin_earliest, "participant"]
+    )
+  end
+
+  it "issues qualifications separately per event_kind, even for the same person" do
+    person = people(:mitglied)
+    training_a = create_invalid_external_training(2.2, finish_at: Date.new(2024, 1, 1),
+      person: person, event_kind: event_kinds(:ski_course))
+    training_b = create_invalid_external_training(4.7, finish_at: Date.new(2024, 2, 1),
+      person: person, event_kind: event_kinds(:slk))
+
+    calls = []
+    allow(ExternalTrainings::Qualifier).to receive(:new) do |qualified_person, training, role|
+      calls << [qualified_person, training, role]
+      instance_double(ExternalTrainings::Qualifier, issue: true)
+    end
+
+    job.perform
+
+    expect(calls).to contain_exactly(
+      [person, training_a, "participant"],
+      [person, training_b, "participant"]
+    )
+  end
+
+  describe "with a real qualification" do
+    let(:today) { Date.new(2024, 3, 26) }
+    let(:person) { people(:mitglied) }
+    let(:qualification_kind) { qualification_kinds(:ski_leader) }
+
+    before { travel_to(today) }
+
+    it "prolongs the qualification once the corrected training_days meet the requirement" do
+      Fabricate(:qualification, qualification_kind: qualification_kind, person: person,
+        start_at: today - 2.years, qualified_at: today - 2.years)
+      training = create_invalid_external_training(1.6, finish_at: today, person: person)
+
+      expect { job.perform }.to change { person.qualifications.count }.by(1)
+
+      expect(training.reload.training_days).to eq(2.0)
+    end
+
+    it "does not prolong the qualification if the corrected training_days still fall short" do
+      Fabricate(:qualification, qualification_kind: qualification_kind, person: person,
+        start_at: today - 2.years, qualified_at: today - 2.years)
+      training = create_invalid_external_training(1.1, finish_at: today, person: person)
+
+      expect { job.perform }.not_to change { person.qualifications.count }
+
+      expect(training.reload.training_days).to eq(1.5)
+    end
+  end
+end

--- a/spec/models/external_training_spec.rb
+++ b/spec/models/external_training_spec.rb
@@ -13,9 +13,9 @@ describe ExternalTraining do
   let(:today) { Date.new(2024, 3, 26) }
 
   describe "validations" do
-    def build(start_at:, finish_at:)
+    def build(start_at: today, finish_at: today, training_days: 1)
       Fabricate.build(:external_training, person: people(:mitglied), start_at: start_at,
-        finish_at: finish_at)
+        finish_at: finish_at, training_days: training_days)
     end
 
     it "is invalid when finish_at is before start_at" do
@@ -49,6 +49,22 @@ describe ExternalTraining do
     it "is valid when finish_at is before today" do
       external_training = build(start_at: 10.days.ago, finish_at: 5.days.ago)
       expect(external_training).to be_valid
+    end
+
+    [2, 4.5, 0.5, 10.0].each do |training_days|
+      it "is valid when training_days is #{training_days}" do
+        expect(build(training_days: training_days)).to be_valid
+      end
+    end
+
+    [2.2, 4.3, 0.1, 1.75].each do |training_days|
+      it "is invalid when training_days is #{training_days}" do
+        external_training = build(training_days: training_days)
+        expect(external_training).to_not be_valid
+        expect(external_training.errors.full_messages).to include(
+          "Ausbildungstage muss eine ganze oder halbe Zahl sein"
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Laut Ticket soll vorher noch eine Liste der betroffenen Personen gemacht werden.
Ich frag mich grad noch was da so der beste Approach ist damit das nicht vergessen geht. Man könnte den Job beispielsweise nicht via Migration sondern manuell triggern damit man vorher direkt noch die Liste der Personen ziehen kann oder man denkt tatsächlich vor dem Release dran.. Haben wir da schonmal was in die Richtung gemacht?